### PR TITLE
docs: sync README and API docs with recent CLI features

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,8 @@ Supports **UMA** (FAIRChem), **SevenNet** (7net), and **MACE** models with autom
 - Unified CLI commands: `optimize run`, `md run`, `neb run`, `autoneb run`
 - Auto-detection of available MLIP models (UMA > SevenNet > MACE)
 - UMA model support with multiple task types (OMat, OC20, OMol, ODAC)
+- MACE multi-head foundation models (`mace-mh-*`) with selectable heads (`omat_pbe`, `oc20_usemppbe`, `matpes_r2scan`, …)
+- GPU/CPU selection via `--device` (`auto`/`cuda`/`cpu`) on all run commands
 - Geometry optimization with multiple optimizers (FIRE, BFGS, LBFGS, BFGSLineSearch, GPMin, MDMin)
 - MD with NVE, NVT, and NPT ensembles
 - Configurable thermostats (Langevin, Nose-Hoover, Berendsen) and barostats (MTK NPT, Berendsen NPT)
@@ -76,6 +78,20 @@ The package installs the following entry points:
 
 `mlip <subcmd>` is equivalent to running `<subcmd>` directly. For example, `mlip md run --structure POSCAR` and `md run --structure POSCAR` do the same thing. The examples below use the standalone form for brevity. All commands support `--help`.
 
+### Common model options
+
+These apply to `optimize`, `md`, `neb`, `autoneb`, and `benchmark`:
+
+- `--mlip`: Model tag. `auto` (default) picks the first installed in order **UMA → SevenNet → MACE → CHGNet**, or pass an explicit tag: any `uma-*` (e.g. `uma-s-1p2`), `mace` (MACE-MP-0), `mace-mh-1` (multi-head foundation), `7net-mf-ompa`, `chgnet`.
+- `--uma-task`: Task head for UMA models — `omat` (default, bulk inorganic), `oc20` (catalysis/surfaces), `omol` (molecules), `odac`. Ignored for non-UMA models.
+- `--mace-head`: Head for multi-head MACE models (`mace-mh-*`) — `omat_pbe` (default), `oc20_usemppbe`, `matpes_r2scan`, `mp_pbe_refit_add`, `omol`, `spice_wB97M`. Ignored for plain `mace`.
+- `--device`: `auto` (default; cuda if available, else cpu), `cuda`, or `cpu`. On multi-GPU nodes set `CUDA_VISIBLE_DEVICES` to choose the GPU.
+
+**Example (multi-head MACE on a catalysis surface, forced to GPU):**
+```bash
+optimize run --structure POSCAR --mlip mace-mh-1 --mace-head oc20_usemppbe --device cuda
+```
+
 ### Geometry Optimization
 ```bash
 optimize run --structure path/to/structure.vasp
@@ -86,10 +102,16 @@ optimize run --structure path/to/structure.vasp
 - `--optimizer`: Algorithm (default: `bfgs`; also `fire`, `lbfgs`, `bfgsls`, `gpmin`, `mdmin`)
 - `--fmax`: Force convergence threshold in eV/Å (default: `0.05`)
 - `--max-steps`: Maximum optimization steps (default: `200`)
+- `--relax-cell`: Also relax the simulation cell (VASP ISIF=3-equivalent), wrapping the atoms in ASE's `FrechetCellFilter`. Off by default (positions only).
 
-**Example:**
+**Example (positions only):**
 ```bash
 optimize run --structure POSCAR --mlip uma-s-1p2 --optimizer fire --fmax 0.05
+```
+
+**Example (full cell + positions relaxation):**
+```bash
+optimize run --structure POSCAR --relax-cell --optimizer fire --fmax 0.02
 ```
 
 **Outputs:** `opt.traj`, `opt.log`, `opt_convergence.csv`, `opt_convergence.png`, `opt_final.vasp`, `opt_params.txt`
@@ -109,6 +131,9 @@ md run --structure path/to/structure.vasp
 - `--timestep`: Timestep in fs
 - `--thermostat`: For NVT (`langevin`, `nose-hoover`, `berendsen`)
 - `--barostat`: For NPT (`npt`, `berendsen`)
+- `--log-interval`: Append a row to `md_energy.csv` every N steps (default: 10)
+- `--traj-interval`: Write a frame to `md.traj` every N steps (default: 100)
+- `--resume`: Continue an existing run — loads the last frame of `md.traj`, preserves momenta, and treats `--steps` as *additional* steps
 - `--mlip`: Model choice (default: `auto`)
 
 For the full MD parameter list, defaults, recommended values for solids, and worked examples, see [MD_REFERENCE.md](docs/MD_REFERENCE.md).
@@ -121,6 +146,11 @@ md run --structure POSCAR --ensemble nvt --temperature 300 --steps 5000 --thermo
 **Example (NPT with Berendsen barostat):**
 ```bash
 md run --structure POSCAR --ensemble npt --temperature 300 --pressure 0.0 --steps 10000 --barostat berendsen
+```
+
+**Example (extend a finished run by 5000 more steps):**
+```bash
+md run --structure POSCAR --resume --steps 5000
 ```
 
 **Outputs:** `md.traj`, `md_energy.csv`, `md_energy.png`, `md_temperature.png`, `md_pressure.png` (NPT), `md_volume.png` (NPT), `md_params.txt`

--- a/docs/MD_REFERENCE.md
+++ b/docs/MD_REFERENCE.md
@@ -80,8 +80,13 @@ Nose-Hoover requires a recent ASE; the platform raises `ImportError` if it is mi
 | `--ttime` | `25.0` | fs | Time constant for Nose-Hoover and NPT (MTK) |
 | `--taut` | `100.0` | fs | Berendsen temperature coupling time |
 | `--taup` | `1000.0` | fs | Berendsen pressure coupling time (NPT Berendsen only) |
-| `--mlip` | `auto` | — | MLIP model; auto-detect or explicit (`uma-s-1p2`, `mace`, `7net-mf-ompa`, `chgnet`, …) |
+| `--mlip` | `auto` | — | MLIP model; auto-detect or explicit (`uma-s-1p2`, `mace`, `mace-mh-1`, `7net-mf-ompa`, `chgnet`, …) |
 | `--uma-task` | `omat` | — | Task head for UMA models: `omat`, `oc20`, `omol`, `odac` |
+| `--mace-head` | `omat_pbe` | — | Head for multi-head MACE foundation models (`mace-mh-*`): `omat_pbe`, `oc20_usemppbe`, `matpes_r2scan`, `mp_pbe_refit_add`, `omol`, `spice_wB97M`. Ignored for non-MH MACE |
+| `--device` | `auto` | — | Compute device: `auto` (cuda if available, else cpu), `cuda`, or `cpu`. On multi-GPU nodes use `CUDA_VISIBLE_DEVICES` to pick the GPU |
+| `--log-interval` | `10` | steps | Append a row to `md_energy.csv` (and drive the stdout MDLogger) every N steps. At dt=0.5 fs, 10 → one row every 5 fs |
+| `--traj-interval` | `100` | steps | Write a frame to `md.traj` every N steps. Lower for finer dynamics; raise to shrink disk |
+| `--csv-flush-every` | `100` | log calls | Flush buffered `md_energy.csv` rows to disk every N log calls. `0` disables incremental writes (flush only at end) |
 | `--resume` | off | flag | Continue an existing run in the structure's directory. The last frame of `md.traj` is loaded as the starting state, momenta are preserved (no Maxwell-Boltzmann re-init), and `--steps` is interpreted as *additional* steps. New rows append to `md_energy.csv` and the trajectory; `md_params.txt` gets a `--- Resume invocation ---` block appended. Plots are regenerated over the full chain. |
 
 **Not exposed on the CLI** but used internally with sensible defaults:
@@ -112,7 +117,7 @@ Every `md run` invocation writes the following to the directory containing the i
 
 | File | Contents |
 |------|----------|
-| `md.traj` | Full ASE trajectory (every `interval` steps) |
+| `md.traj` | Full ASE trajectory (every `--traj-interval` steps) |
 | `md_energy.csv` | Step, time (fs), temperature (K), total / potential / kinetic energy (eV); plus `pressure(GPa)` and `volume(A^3)` columns for NPT |
 | `md_energy.png` | Total / potential / kinetic energy vs time |
 | `md_temperature.png` | Temperature vs time, with target line for NVT/NPT |

--- a/docs/PYTHON_API.md
+++ b/docs/PYTHON_API.md
@@ -6,7 +6,7 @@ The CLI commands wrap a small set of pure-Python functions and one class. This p
 
 | Module | Public symbol | Purpose |
 |--------|---------------|---------|
-| `mlip_platform.cli.utils` | `setup_calculator(atoms, mlip, uma_task)` | Attach the right MLIP calculator to an `Atoms` object |
+| `mlip_platform.cli.utils` | `setup_calculator(atoms, mlip, uma_task="omat", device="auto", mace_head="omat_pbe")` | Attach the right MLIP calculator to an `Atoms` object |
 | `mlip_platform.cli.utils` | `detect_mlip()` / `validate_mlip(name)` / `resolve_mlip(name)` | Auto-detect / validate MLIP availability |
 | `mlip_platform.core.optimize` | `run_optimization(atoms, ...)` | Geometry optimization with progress logging and plots |
 | `mlip_platform.core.optimize` | `OPTIMIZER_MAP` | dict of supported ASE optimizers |
@@ -34,10 +34,13 @@ setup_calculator(atoms, mlip="uma-s-1p2", uma_task="omat")  # mutates atoms.calc
 
 `setup_calculator` accepts:
 
-- `mlip="mace"` → MACE MP medium (CPU)
+- `mlip="mace"` → MACE-MP-0 medium
+- `mlip="mace-mh-1"` (or any `mace-mh-*`) → multi-head MACE foundation model; `mace_head` selects the head (`omat_pbe` default, `oc20_usemppbe`, `matpes_r2scan`, `mp_pbe_refit_add`, `omol`, `spice_wB97M`)
 - `mlip="7net-mf-ompa"` → SevenNet 7net-mf-ompa (mpa modal)
 - `mlip="uma-..."` → any FAIRChem UMA tag, with `uma_task` selecting the head (`omat`, `oc20`, `omol`, `odac`)
 - `mlip="chgnet"` → CHGNet default model
+
+`device` selects the compute device (`"auto"` → cuda if available else cpu, or force `"cuda"` / `"cpu"`). `mace_head` is ignored for non-MH models; `uma_task` is ignored for non-UMA models.
 
 Auto-detection is also exposed:
 
@@ -66,6 +69,7 @@ converged = run_optimization(
     optimizer="bfgs",   # or "fire", "lbfgs", "bfgsls", "gpmin", "mdmin"
     fmax=0.05,
     max_steps=200,
+    relax_cell=False,   # True → also relax the cell (VASP ISIF=3-equivalent)
     output_dir="./relaxed",
     model_name="uma-s-1p2",
 )
@@ -102,7 +106,8 @@ run_md(
     timestep=1.0,
     friction=0.01,
     steps=10000,
-    interval=10,
+    log_interval=10,    # rows appended to md_energy.csv every N steps
+    traj_interval=100,  # frames written to md.traj every N steps
     output_dir="./md",
     model_name="uma-s-1p2",
 )
@@ -188,10 +193,10 @@ neb.export_poscars()
 | `optimize_endpoints(endpoint_fmax=0.01, optimizer="BFGS", max_steps=200)` | Pre-relax both endpoints, return a results dict and write `initial_opt.*` / `final_opt.*` |
 | `run_neb(optimizer=FIRE, trajectory="A2B.traj", full_traj="A2B_full.traj", climb=False, max_steps=600)` | Run NEB optimization, return the final image list |
 | `run_autoneb(n_simul, n_max, k, climb, optimizer, space_energy_ratio, interpolate_method, maxsteps, prefix)` | Run AutoNEB with dynamic image insertion |
-| `process_results()` | Returns a pandas `DataFrame` with one row per image: image index, energy, relative energy, force info |
+| `process_results()` | Returns a pandas `DataFrame` with one row per image and columns `image_index`, `energy`, `relative_energy` |
 | `plot_results(df)` | Saves `neb_energy.png` (smoothed energy profile, barrier annotation) |
 | `export_poscars()` | Writes `00/POSCAR`, `01/POSCAR`, ... for every image |
-| `CustomNEB.load_from_restart(output_dir, **overrides)` | Class method; reload a previous run from `A2B_full.traj` + `neb_parameters.txt`, with optional MLIP / fmax / k / climb / optimizer overrides |
+| `CustomNEB.load_from_restart(output_dir, mlip=None, uma_task=None, fmax=None, logfile=None, k=None, climb=None, neb_optimizer=None, neb_max_steps=None)` | Class method; reload a previous run from `A2B_full.traj` + `neb_parameters.txt`. Any non-`None` keyword overrides the corresponding saved parameter |
 
 `load_from_restart` is the entry point used by `neb run --restart`. It returns `(neb_instance, loaded_params)`.
 


### PR DESCRIPTION
Recent commits added CLI features that never reached the docs. Close the gaps and fix a crash-causing example.

- README: document optimize --relax-cell, md --resume/--log-interval/ --traj-interval, MACE multi-head models, and a shared "Common model options" section (--mlip/--uma-task/--mace-head/--device)
- MD_REFERENCE: add the five missing flags to the parameter table (--mace-head, --device, --log-interval, --traj-interval, --csv-flush-every); fix stale `interval` reference
- PYTHON_API: fix run_md example that called a nonexistent `interval` kwarg (raised TypeError); update setup_calculator signature, drop the stale mace "(CPU)" label, add mace-mh-* and relax_cell, correct process_results columns and load_from_restart keywords