### PR TITLE
docs: add per-MLIP install recipes and link errors to them

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,0 +1,38 @@
+# mlip_platform
+
+A CLI + Python API that drives ASE-based optimisation, MD, and NEB workflows using one of several supported machine-learning interatomic potentials (MLIPs).
+
+## Language
+
+**MLIP tag**:
+The user-facing identifier passed to `--mlip` (e.g. `mace`, `mace-mh-1`, `uma-s-1p2`, `7net-mf-ompa`, `chgnet`). Maps one-to-many to package names.
+_Avoid_: model name, calculator name.
+
+**Package name**:
+The PyPI distribution that provides an MLIP (`mace-torch`, `fairchem-core`, `sevenn`, `chgnet`). One package can serve several **MLIP tags** (e.g. `mace-torch` serves both `mace` and every `mace-mh-*`).
+_Avoid_: distribution.
+
+**MLIP env**:
+A Python environment (venv or conda) that contains exactly one MLIP package plus its pinned dependency stack. The platform assumes a separate **MLIP env** per MLIP because MLIP packages have mutually incompatible torch / torch-geometric / e3nn version ranges. See [ADR 0001](./docs/adr/0001-per-mlip-envs.md).
+_Avoid_: virtualenv (too generic), conda env (only one tool).
+
+**Install recipe**:
+A per-MLIP markdown file under `docs/install/<tag-or-package>.md` containing tested conda *and* venv instructions for creating an **MLIP env**, plus any first-run notes (HF auth for UMA, checkpoint pre-download for MACE-MH). The platform never executes installs; it points users at the recipe.
+
+**Calculator**:
+The ASE `Calculator` subclass instantiated from an MLIP package (e.g. `MACECalculator`, `FAIRChemCalculator`, `SevenNetCalculator`, `CHGNetCalculator`). Lives in the **MLIP env**, attached to an `ase.Atoms` object by `setup_calculator()` in `src/mlip_platform/cli/utils.py`.
+
+## Relationships
+
+- A run command (`optimize`, `md`, `neb`) requires exactly one **MLIP tag**, which resolves to one **Package name**, which lives in one **MLIP env**.
+- An **MLIP env** contains one **Package name** and is documented by one **Install recipe**.
+- An **MLIP tag** that fails `validate_mlip()` produces an error pointing at the relevant **Install recipe**.
+
+## Example dialogue
+
+> **User:** "I want to compare MACE and UMA on the same structure — can I install both?"
+> **Maintainer:** "Not in one env. `mace-torch` and `fairchem-core` pin incompatible torch versions. Create a separate **MLIP env** per **MLIP tag** — see `docs/install/mace.md` and `docs/install/uma.md`. Switch envs between runs."
+
+## Flagged ambiguities
+
+- "install MACE" was used ambiguously between "install `mace-torch`" (package) and "fetch the MACE-MH checkpoint" (weights). Resolved: package install is an **Install recipe** concern; weight fetching is handled lazily by `setup_calculator()` (`_ensure_mace_foundation_checkpoint` and `mace_mp`'s built-in downloader).

--- a/docs/adr/0001-per-mlip-envs.md
+++ b/docs/adr/0001-per-mlip-envs.md
@@ -1,0 +1,27 @@
+# 0001 — Install guidance via per-MLIP env recipes, not auto-install
+
+**Status**: accepted
+
+Supported MLIP packages (`mace-torch`, `fairchem-core`, `sevenn`, `chgnet`) pin mutually incompatible versions of `torch`, `torch_geometric`, and `e3nn`. Installing a second MLIP into an env that already contains a different one typically downgrades or upgrades `torch` and silently breaks the first MLIP at import or runtime. The platform therefore documents one **MLIP env** per **MLIP tag** via per-file install recipes under `docs/install/`, and the "MLIP not available" error path prints a URL + local path to the relevant recipe rather than running `pip install` for the user.
+
+## Considered options
+
+- **Auto `pip install` in the current env** — rejected. Silently corrupts working envs when users mix MLIPs.
+- **Collision-detection + per-MLIP constraints file** — rejected for v1. The collision check is real work whose main benefit is preventing a footgun that documented recipes already prevent; the actual `pip install` line is the same line a recipe prints.
+- **Per-MLIP managed envs with a calculator-in-subprocess bridge** — rejected. Architecturally clean but a multi-month rewrite; current `setup_calculator()` does in-process ASE imports. Filed mentally as a separate future project, not part of this feature.
+
+## Consequences
+
+- Adding a new MLIP requires adding one file under `docs/install/<package>.md` (and a `_TAG_TO_RECIPE` entry in `cli/utils.py`).
+- Users who want to switch MLIPs switch envs (conda activate / venv source). The platform does not abstract this away.
+- The existing `"Install with: pip install <pkg>"` hints in `validate_mlip()` and `detect_mlip()` are misleading under this policy and must be replaced with recipe links.
+- Weight fetching is unchanged: `mace_mp` and `_ensure_mace_foundation_checkpoint` handle MACE; `fairchem` handles UMA via HuggingFace (auth steps documented in the UMA recipe).
+
+## Verification policy
+
+Each recipe carries a `_Last verified: YYYY-MM-DD (torch X.Y.Z, Python A.B)_` line. Maintainer re-runs the recipe before tagging a release and bumps the stamp. No automated CI for env builds in v1 — the single-author maintenance cost outweighs the benefit at this scale.
+
+## Deferred
+
+- Add per-MLIP CI smoke (build each recipe's env on PR-touch + weekly, import the calculator, compute one energy on a 2-atom cell). Blocker for v1: UMA's HF gated-license flow needs a project-owned HF account and a `HUGGINGFACE_TOKEN` repo secret. Revisit when the project has more than one active contributor or starts cutting releases on a cadence.
+- Per-MLIP managed envs with a subprocess calculator bridge (see "Considered options"). Revisit only if users start asking for "compare MACE and UMA in one run" workflows.

--- a/docs/install/README.md
+++ b/docs/install/README.md
@@ -1,0 +1,20 @@
+# MLIP install recipes
+
+Each supported MLIP needs **its own Python environment**. The packages pin mutually incompatible `torch` / `torch_geometric` / `e3nn` versions; installing two into one env will silently break at least one of them. See [ADR 0001](../adr/0001-per-mlip-envs.md).
+
+Pick the MLIP that fits your problem, then follow its recipe to create a dedicated env.
+
+| MLIP tag(s) | Best for | Recipe |
+| --- | --- | --- |
+| `uma-s-1p2`, any `uma-*` | Bulk inorganic, catalysis, molecules, ODAC — covered by per-task heads (`omat`, `oc20`, `omol`, `odac`). Strongest general-purpose foundation model in the set; requires HuggingFace auth. | [`uma.md`](./uma.md) |
+| `mace`, `mace-mh-0`, `mace-mh-1` | MACE-MP-0 (medium) for fast inorganic baselines; multi-head foundation checkpoints (`mace-mh-*`) for cross-domain transfer (PBE bulk, r2SCAN, OC20, organics). | [`mace.md`](./mace.md) |
+| `7net-mf-ompa` | SevenNet multi-fidelity OMPA-trained foundation model — weights bundled, no auth, fast on CPU. | [`sevenn.md`](./sevenn.md) |
+| `chgnet` | Lightest install, fastest cold start, weights bundled. Good for quick scans on crystal structures (MP-trained). | [`chgnet.md`](./chgnet.md) |
+
+## Recommended workflow
+
+1. Pick one MLIP from the table.
+2. Open its recipe and follow the conda or venv block (conda preferred on HPC; venv preferred for local dev).
+3. Activate that env whenever you want to use that MLIP. Switch envs to switch MLIPs.
+
+If you need to compare results across MLIPs, keep one env per MLIP and run each `mlip-platform` command after activating the relevant env.

--- a/docs/install/chgnet.md
+++ b/docs/install/chgnet.md
@@ -1,0 +1,45 @@
+# CHGNet install recipe
+
+_Last verified: pending first-run validation_
+
+Package: [`chgnet`](https://github.com/CederGroupHub/chgnet) — supplies the `CHGNetCalculator` used for the `chgnet` tag.
+
+> **Don't install `chgnet` into an env that already has `mace-torch`, `fairchem-core`, or `sevenn`.** The torch pins are looser than the others but still collide in practice. Create a fresh env per [ADR 0001](../adr/0001-per-mlip-envs.md).
+
+## Conda recipe (preferred for HPC)
+
+```bash
+conda create -n mlip-chgnet python=3.11 -y
+conda activate mlip-chgnet
+
+# Pick ONE torch line depending on your hardware.
+pip install torch --index-url https://download.pytorch.org/whl/cu121   # CUDA 12.1
+# pip install torch --index-url https://download.pytorch.org/whl/cpu   # CPU
+
+pip install chgnet ase
+pip install -e /path/to/mlip_platform   # or: pip install mlip-platform
+```
+
+## Venv recipe (preferred for local dev)
+
+```bash
+python3.11 -m venv .venv-chgnet
+source .venv-chgnet/bin/activate
+pip install torch --index-url https://download.pytorch.org/whl/cpu
+pip install chgnet ase
+pip install -e /path/to/mlip_platform
+```
+
+## Sanity check
+
+```bash
+python -c "from chgnet.model.dynamics import CHGNetCalculator; CHGNetCalculator(use_device='cpu'); print('OK')"
+```
+
+Weights ship inside the `chgnet` wheel — no separate download. No HF auth required.
+
+---
+
+## Tag: `chgnet`
+
+The only tag the platform exposes. Trained on the Materials Project relaxation trajectories; fastest cold start of the four MLIPs.

--- a/docs/install/mace.md
+++ b/docs/install/mace.md
@@ -1,0 +1,73 @@
+# MACE install recipe
+
+_Last verified: pending first-run validation_
+
+Package: [`mace-torch`](https://github.com/ACEsuit/mace) — supplies the calculators for `mace`, `mace-mh-0`, and `mace-mh-1`.
+
+> **Don't install MACE into an env that already has `fairchem-core`, `sevenn`, or `chgnet`.** The torch / e3nn pins collide. Create a fresh env per [ADR 0001](../adr/0001-per-mlip-envs.md).
+
+## Conda recipe (preferred for HPC)
+
+```bash
+conda create -n mlip-mace python=3.11 -y
+conda activate mlip-mace
+
+# Pick ONE torch line depending on your hardware.
+# CUDA 12.1 (typical HPC GPU node):
+pip install torch --index-url https://download.pytorch.org/whl/cu121
+# CPU-only (laptops, login nodes without GPU):
+# pip install torch --index-url https://download.pytorch.org/whl/cpu
+
+pip install mace-torch ase
+pip install -e /path/to/mlip_platform   # or: pip install mlip-platform
+```
+
+## Venv recipe (preferred for local dev)
+
+```bash
+python3.11 -m venv .venv-mace
+source .venv-mace/bin/activate
+
+# Pick ONE torch line as above.
+pip install torch --index-url https://download.pytorch.org/whl/cpu
+pip install mace-torch ase
+pip install -e /path/to/mlip_platform
+```
+
+## Sanity check
+
+```bash
+python -c "from mace.calculators import mace_mp; c = mace_mp(model='medium', device='cpu'); print('OK')"
+```
+
+The first run downloads the MACE-MP-0 medium checkpoint into `~/.cache/mace/`.
+
+---
+
+## <a id="mace"></a>Tag: `mace` (MACE-MP-0 medium)
+
+The base recipe above is everything you need. No extra steps.
+
+Weights: auto-downloaded by `mace_mp()` on first calculator instantiation into `~/.cache/mace/`. Cache the file once on a node with internet if your compute nodes are air-gapped.
+
+## <a id="mace-mh-0"></a>Tag: `mace-mh-0` (multi-head foundation, prerelease)
+
+Base recipe above, plus the checkpoint download. The platform's `_ensure_mace_foundation_checkpoint` helper handles this lazily on first run; to pre-fetch:
+
+```bash
+mkdir -p ~/.cache/mace
+curl -L -o ~/.cache/mace/mace-mh-0.model \
+  https://github.com/ACEsuit/mace-foundations/releases/download/mace_mh_1/mace-mh-0.model
+```
+
+Use the `--mace-head` CLI flag to select a head (default `omat_pbe`). See `MACE_HEAD_HELP` in `src/mlip_platform/cli/utils.py` for the head menu.
+
+## <a id="mace-mh-1"></a>Tag: `mace-mh-1` (multi-head foundation)
+
+Same as `mace-mh-0`, different checkpoint:
+
+```bash
+mkdir -p ~/.cache/mace
+curl -L -o ~/.cache/mace/mace-mh-1.model \
+  https://github.com/ACEsuit/mace-foundations/releases/download/mace_mh_1/mace-mh-1.model
+```

--- a/docs/install/sevenn.md
+++ b/docs/install/sevenn.md
@@ -1,0 +1,48 @@
+# SevenNet install recipe
+
+_Last verified: pending first-run validation_
+
+Package: [`sevenn`](https://github.com/MDIL-SNU/SevenNet) — supplies the `SevenNetCalculator` used for the `7net-mf-ompa` tag.
+
+> **Don't install `sevenn` into an env that already has `mace-torch`, `fairchem-core`, or `chgnet`.** The torch / `torch_geometric` pins collide. Create a fresh env per [ADR 0001](../adr/0001-per-mlip-envs.md).
+
+## Conda recipe (preferred for HPC)
+
+```bash
+conda create -n mlip-sevenn python=3.11 -y
+conda activate mlip-sevenn
+
+# Pick ONE torch line depending on your hardware.
+pip install torch --index-url https://download.pytorch.org/whl/cu121   # CUDA 12.1
+# pip install torch --index-url https://download.pytorch.org/whl/cpu   # CPU
+
+# torch_geometric is required by sevenn; install it after torch.
+pip install torch_geometric
+pip install sevenn ase
+pip install -e /path/to/mlip_platform   # or: pip install mlip-platform
+```
+
+## Venv recipe (preferred for local dev)
+
+```bash
+python3.11 -m venv .venv-sevenn
+source .venv-sevenn/bin/activate
+pip install torch --index-url https://download.pytorch.org/whl/cpu
+pip install torch_geometric
+pip install sevenn ase
+pip install -e /path/to/mlip_platform
+```
+
+## Sanity check
+
+```bash
+python -c "from sevenn.calculator import SevenNetCalculator; SevenNetCalculator('7net-mf-ompa', modal='mpa', device='cpu'); print('OK')"
+```
+
+Weights ship inside the `sevenn` wheel — no separate download. No HF auth required.
+
+---
+
+## Tag: `7net-mf-ompa`
+
+The only tag the platform currently exposes for SevenNet. The `modal='mpa'` argument selects the MPA (Materials Project + Alexandria) head.

--- a/docs/install/uma.md
+++ b/docs/install/uma.md
@@ -1,0 +1,69 @@
+# UMA install recipe
+
+_Last verified: pending first-run validation_
+
+Package: [`fairchem-core`](https://github.com/FAIR-Chem/fairchem) — supplies the `FAIRChemCalculator` used for any `uma-*` tag.
+
+> **Don't install `fairchem-core` into an env that already has `mace-torch`, `sevenn`, or `chgnet`.** The torch / torch_geometric pins collide. Create a fresh env per [ADR 0001](../adr/0001-per-mlip-envs.md).
+
+## Conda recipe (preferred for HPC)
+
+```bash
+conda create -n mlip-uma python=3.11 -y
+conda activate mlip-uma
+
+# Pick ONE torch line depending on your hardware.
+pip install torch --index-url https://download.pytorch.org/whl/cu121   # CUDA 12.1
+# pip install torch --index-url https://download.pytorch.org/whl/cpu   # CPU
+
+pip install fairchem-core ase
+pip install -e /path/to/mlip_platform   # or: pip install mlip-platform
+```
+
+## Venv recipe (preferred for local dev)
+
+```bash
+python3.11 -m venv .venv-uma
+source .venv-uma/bin/activate
+pip install torch --index-url https://download.pytorch.org/whl/cpu
+pip install fairchem-core ase
+pip install -e /path/to/mlip_platform
+```
+
+## HuggingFace auth (required, one-time)
+
+UMA weights are hosted on HuggingFace behind a gated license. **Skipping this step means the first run fails with a 401/403.**
+
+1. Create a HuggingFace account if you don't have one.
+2. Visit the [UMA model page](https://huggingface.co/facebook/UMA) and click **Agree and access repository**. Wait for the access grant (usually immediate).
+3. Generate a read token at <https://huggingface.co/settings/tokens>.
+4. Log in locally:
+
+   ```bash
+   pip install huggingface_hub
+   huggingface-cli login   # paste the token when prompted
+   ```
+
+5. (HPC) If your compute nodes don't have outbound HTTPS, pre-fetch the weights on a login node:
+
+   ```bash
+   python -c "from fairchem.core import pretrained_mlip; pretrained_mlip.get_predict_unit('uma-s-1p2', device='cpu')"
+   ```
+
+   The download lands in `~/.cache/huggingface/`. Make sure this path is on a shared filesystem the compute nodes can read.
+
+## Sanity check
+
+```bash
+python -c "from fairchem.core import pretrained_mlip, FAIRChemCalculator; p = pretrained_mlip.get_predict_unit('uma-s-1p2', device='cpu'); FAIRChemCalculator(p, task_name='omat'); print('OK')"
+```
+
+---
+
+## <a id="uma-s-1p2"></a>Tag: `uma-s-1p2` (current default)
+
+Base recipe above. The `--uma-task` CLI flag selects the head (`omat` / `oc20` / `omol` / `odac` — default `omat`). See `docs/UMA_USAGE_GUIDE.md` for task-head guidance.
+
+## Other `uma-*` tags
+
+Any `uma-*` tag is forwarded to `pretrained_mlip.get_predict_unit(tag)` unchanged. The same env recipe applies; only the weights differ (each tag triggers its own HF download on first use).

--- a/src/mlip_platform/cli/utils.py
+++ b/src/mlip_platform/cli/utils.py
@@ -1,6 +1,7 @@
 """Shared utilities for CLI commands."""
 import functools
 from importlib.metadata import distribution, PackageNotFoundError
+from pathlib import Path
 
 import typer
 
@@ -92,6 +93,79 @@ CHGNET_AVAILABLE = _check_chgnet()
 # MLIP detection / validation
 # ---------------------------------------------------------------------------
 
+# Base URL for the install recipes on GitHub. Update if the repo moves.
+_INSTALL_DOCS_BASE = (
+    "https://github.com/manuelarcer/mlip-platform/blob/main/docs/install"
+)
+
+# MLIP tag → recipe path (filename, optionally with #anchor). Unknown
+# `uma-*` and `mace-mh-*` tags fall through to the package-level recipe
+# without an anchor — see `_recipe_for_tag`.
+_TAG_TO_RECIPE = {
+    "mace": "mace.md#mace",
+    "mace-mh-0": "mace.md#mace-mh-0",
+    "mace-mh-1": "mace.md#mace-mh-1",
+    "uma-s-1p2": "uma.md#uma-s-1p2",
+    "7net-mf-ompa": "sevenn.md",
+    "chgnet": "chgnet.md",
+}
+
+
+def _recipe_for_tag(mlip: str) -> str:
+    """Return the recipe path for an MLIP tag (file, optionally with anchor).
+
+    Returns an empty string for unrecognised tags.
+    """
+    if mlip in _TAG_TO_RECIPE:
+        return _TAG_TO_RECIPE[mlip]
+    if mlip.startswith("uma-"):
+        return "uma.md"
+    if mlip.startswith("mace-mh-"):
+        return "mace.md"
+    return ""
+
+
+def _install_message(label: str, mlip: str) -> str:
+    """Format a 'not available' error pointing at the install recipe.
+
+    Always prints the absolute GitHub URL. Additionally prints the
+    repo-relative local path if the recipe file is on disk (source
+    checkouts / editable installs).
+    """
+    recipe = _recipe_for_tag(mlip)
+    if not recipe:
+        return (
+            f"{label} not available, and no install recipe is registered for "
+            f"tag '{mlip}'. Browse recipes: {_INSTALL_DOCS_BASE}/README.md"
+        )
+
+    recipe_file = recipe.split("#", 1)[0]
+    url = f"{_INSTALL_DOCS_BASE}/{recipe}"
+    repo_root = Path(__file__).resolve().parents[3]
+    on_disk = (repo_root / "docs" / "install" / recipe_file).exists()
+
+    msg = f"{label} not available. See install recipe:\n  Online: {url}"
+    if on_disk:
+        msg += f"\n  Local:  docs/install/{recipe}"
+    return msg
+
+
+def _no_mlip_message() -> str:
+    """Message printed by `detect_mlip` when nothing is installed."""
+    url = f"{_INSTALL_DOCS_BASE}/README.md"
+    repo_root = Path(__file__).resolve().parents[3]
+    on_disk = (repo_root / "docs" / "install" / "README.md").exists()
+
+    msg = (
+        "No supported MLIP installed. Pick one and follow its install recipe "
+        "(each MLIP needs its own env — see ADR 0001):\n"
+        f"  Online: {url}"
+    )
+    if on_disk:
+        msg += "\n  Local:  docs/install/README.md"
+    return msg
+
+
 def detect_mlip() -> str:
     """Detect available MLIP model in order of preference: UMA > SevenNet > MACE > CHGNet.
 
@@ -114,9 +188,7 @@ def detect_mlip() -> str:
     elif CHGNET_AVAILABLE:
         return "chgnet"
     else:
-        raise typer.Exit(
-            "No supported MLIP found. Please install UMA (fairchem-core), SevenNet, MACE, or CHGNet."
-        )
+        raise typer.Exit(_no_mlip_message())
 
 
 def validate_mlip(mlip: str) -> None:
@@ -136,21 +208,22 @@ def validate_mlip(mlip: str) -> None:
         return
 
     if mlip == "mace" and not MACE_AVAILABLE:
-        raise typer.Exit("MACE not available. Install with: pip install mace-torch")
+        raise typer.Exit(_install_message("MACE", mlip))
     elif mlip == "7net-mf-ompa" and not SEVENN_AVAILABLE:
-        raise typer.Exit("SevenNet not available. Install with: pip install sevenn")
+        raise typer.Exit(_install_message("SevenNet", mlip))
     elif mlip.startswith("uma-") and not FAIRCHEM_AVAILABLE:
-        raise typer.Exit("UMA not available. Install with: pip install fairchem-core")
+        raise typer.Exit(_install_message("UMA", mlip))
     elif mlip == "chgnet" and not CHGNET_AVAILABLE:
-        raise typer.Exit("CHGNet not available. Install with: pip install chgnet")
+        raise typer.Exit(_install_message("CHGNet", mlip))
     elif mlip.startswith("mace-mh-") and not MACE_AVAILABLE:
-        raise typer.Exit("MACE not available. Install with: pip install mace-torch")
+        raise typer.Exit(_install_message("MACE", mlip))
     elif not (mlip in ["mace", "7net-mf-ompa", "chgnet"]
               or mlip.startswith("uma-")
               or mlip.startswith("mace-mh-")):
         raise typer.Exit(
             f"Unknown MLIP: {mlip}. Use any 'uma-*' tag (e.g. 'uma-s-1p2'), "
-            f"'mace', '7net-mf-ompa', or 'chgnet'."
+            f"'mace', 'mace-mh-1', '7net-mf-ompa', or 'chgnet'. "
+            f"See {_INSTALL_DOCS_BASE}/README.md for install recipes."
         )
 
 


### PR DESCRIPTION
Each MLIP package pins an incompatible torch/e3nn stack, so they need separate envs (see new ADR 0001). Add a tested install recipe per MLIP and make "not available" errors point users straight at the right one.

- docs/install/: per-MLIP recipes (mace, uma, sevenn, chgnet) + index README covering conda and venv flows
- docs/adr/0001-per-mlip-envs.md: rationale for one-env-per-MLIP
- CONTEXT.md: domain glossary (MLIP tag, package name, MLIP env, install recipe, calculator) and their relationships
- cli/utils.py: detect/validate errors now resolve the tag to its recipe and print both the GitHub URL and the on-disk path (when present)