### PR TITLE
fix: log MLIP head/task in all parameter files and add NEB MACE-head support

### DIFF
--- a/src/mlip_platform/cli/commands/autoneb.py
+++ b/src/mlip_platform/cli/commands/autoneb.py
@@ -7,7 +7,7 @@ from ase.optimize import FIRE
 
 from mlip_platform.core.neb import CustomNEB
 from mlip_platform.core.params_io import write_parameters_file, write_endpoint_results
-from mlip_platform.cli.utils import MLIP_HELP, UMA_TASK_HELP, parse_relax_atoms, resolve_mlip
+from mlip_platform.cli.utils import MACE_HEAD_HELP, MLIP_HELP, UMA_TASK_HELP, parse_relax_atoms, resolve_mlip
 
 app = typer.Typer()
 
@@ -21,6 +21,7 @@ def run(
     fmax: float = typer.Option(0.05, help="Force convergence threshold (eV/Ang)"),
     mlip: str = typer.Option("auto", help=MLIP_HELP),
     uma_task: str = typer.Option("omat", help=UMA_TASK_HELP),
+    mace_head: str = typer.Option("omat_pbe", help=MACE_HEAD_HELP),
     climb: bool = typer.Option(True, help="Enable climbing image NEB"),
     k: float = typer.Option(0.1, help="Spring constant"),
     space_energy_ratio: float = typer.Option(0.5, help="Preference for geometric (1.0) vs energy (0.0) gaps"),
@@ -49,6 +50,8 @@ def run(
     mlip = resolve_mlip(mlip)
     if mlip.startswith("uma-"):
         typer.echo(f"   UMA task: {uma_task}")
+    if mlip.startswith("mace-mh-"):
+        typer.echo(f"   MACE head: {mace_head}")
 
     output_dir = Path.cwd()
 
@@ -82,6 +85,7 @@ def run(
     param_dict = {
         "MLIP model:": mlip,
         **({f"UMA task:": uma_task} if mlip.startswith("uma-") else {}),
+        **({f"MACE head:": mace_head} if mlip.startswith("mace-mh-") else {}),
         "Initial:": str(initial),
         "Final:": str(final),
         "n_max:": n_max,
@@ -109,7 +113,7 @@ def run(
     neb = CustomNEB(
         initial=atoms_initial, final=atoms_final,
         num_images=5,  # Dummy value, not used by AutoNEB
-        fmax=fmax, mlip=mlip, uma_task=uma_task,
+        fmax=fmax, mlip=mlip, uma_task=uma_task, mace_head=mace_head,
         output_dir=output_dir, relax_atoms=relax_indices,
     )
 

--- a/src/mlip_platform/cli/commands/neb.py
+++ b/src/mlip_platform/cli/commands/neb.py
@@ -10,7 +10,7 @@ from ase.optimize import FIRE, MDMin, BFGS, LBFGS
 
 from mlip_platform.core.neb import CustomNEB
 from mlip_platform.core.params_io import write_parameters_file, write_endpoint_results
-from mlip_platform.cli.utils import MLIP_HELP, UMA_TASK_HELP, parse_relax_atoms, resolve_mlip
+from mlip_platform.cli.utils import MACE_HEAD_HELP, MLIP_HELP, UMA_TASK_HELP, parse_relax_atoms, resolve_mlip
 
 logger = logging.getLogger(__name__)
 
@@ -69,7 +69,7 @@ def create_backup_folder(output_dir: Path):
     return backup_dir, moved_files
 
 
-def _handle_restart(output_dir, *, mlip, uma_task, fmax, log, k, climb,
+def _handle_restart(output_dir, *, mlip, uma_task, mace_head, fmax, log, k, climb,
                     neb_optimizer, neb_max_steps, device):
     """Handle NEB restart mode.
 
@@ -90,7 +90,7 @@ def _handle_restart(output_dir, *, mlip, uma_task, fmax, log, k, climb,
     try:
         neb_instance, loaded_params = CustomNEB.load_from_restart(
             output_dir=output_dir, mlip=mlip, uma_task=uma_task,
-            fmax=fmax, logfile=log, k=k, climb=climb,
+            mace_head=mace_head, fmax=fmax, logfile=log, k=k, climb=climb,
             neb_optimizer=neb_optimizer, neb_max_steps=neb_max_steps,
             device=device,
         )
@@ -103,6 +103,8 @@ def _handle_restart(output_dir, *, mlip, uma_task, fmax, log, k, climb,
     typer.echo(f"   - MLIP model:          {loaded_params['mlip']}")
     if loaded_params.get("uma_task"):
         typer.echo(f"   - UMA task:            {loaded_params['uma_task']}")
+    if loaded_params.get("mace_head"):
+        typer.echo(f"   - MACE head:           {loaded_params['mace_head']}")
     typer.echo(f"   - Intermediate images: {loaded_params['num_images']}")
     typer.echo(f"   - Total images:        {loaded_params['total_images']}")
     if loaded_params.get("relax_atoms"):
@@ -153,6 +155,7 @@ def _handle_restart(output_dir, *, mlip, uma_task, fmax, log, k, climb,
     params = {
         "mlip": mlip or loaded_params["mlip"],
         "uma_task": uma_task or loaded_params.get("uma_task", "omat"),
+        "mace_head": mace_head or loaded_params.get("mace_head", "omat_pbe"),
         "fmax": fmax if fmax is not None else loaded_params["fmax"],
         "k": k if k is not None else loaded_params.get("k", 0.1),
         "climb": climb if climb is not None else loaded_params.get("climb", True),
@@ -171,6 +174,7 @@ def _handle_restart(output_dir, *, mlip, uma_task, fmax, log, k, climb,
         "Restarted from:": backup_dir.name,
         "MLIP model:": params["mlip"],
         **({f"UMA task:": params["uma_task"]} if params["mlip"].startswith("uma-") else {}),
+        **({f"MACE head:": params["mace_head"]} if params["mlip"].startswith("mace-mh-") else {}),
         "Device:": params["device"],
         "Initial:": "(from restart)",
         "Final:": "(from restart)",
@@ -193,7 +197,7 @@ def _handle_restart(output_dir, *, mlip, uma_task, fmax, log, k, climb,
 
 
 def _handle_new_neb(output_dir, initial, final, *, num_images, interp_fmax,
-                    interp_steps, fmax, mlip, uma_task, log, k, climb,
+                    interp_steps, fmax, mlip, uma_task, mace_head, log, k, climb,
                     neb_optimizer, neb_max_steps, optimize_endpoints,
                     endpoint_fmax, endpoint_optimizer, endpoint_max_steps,
                     relax_atoms_str, device):
@@ -226,6 +230,7 @@ def _handle_new_neb(output_dir, initial, final, *, num_images, interp_fmax,
     endpoint_optimizer = endpoint_optimizer or "bfgs"
     endpoint_max_steps = endpoint_max_steps or 200
     device = device or "cpu"
+    mace_head = mace_head or "omat_pbe"
 
     atoms_initial = read(initial, format="vasp")
     atoms_final = read(final, format="vasp")
@@ -237,6 +242,8 @@ def _handle_new_neb(output_dir, initial, final, *, num_images, interp_fmax,
     mlip = resolve_mlip(mlip)
     if mlip.startswith("uma-"):
         typer.echo(f"   UMA task: {uma_task}")
+    if mlip.startswith("mace-mh-"):
+        typer.echo(f"   MACE head: {mace_head}")
 
     # Parse relax_atoms
     relax_indices = None
@@ -247,7 +254,8 @@ def _handle_new_neb(output_dir, initial, final, *, num_images, interp_fmax,
     total_images = num_images + 2
 
     params = {
-        "mlip": mlip, "uma_task": uma_task, "fmax": fmax, "k": k,
+        "mlip": mlip, "uma_task": uma_task, "mace_head": mace_head,
+        "fmax": fmax, "k": k,
         "climb": climb, "neb_optimizer": neb_optimizer,
         "neb_max_steps": neb_max_steps, "log": log,
         "num_images": num_images, "total_images": total_images,
@@ -259,6 +267,7 @@ def _handle_new_neb(output_dir, initial, final, *, num_images, interp_fmax,
     param_dict = {
         "MLIP model:": mlip,
         **({f"UMA task:": uma_task} if mlip.startswith("uma-") else {}),
+        **({f"MACE head:": mace_head} if mlip.startswith("mace-mh-") else {}),
         "Device:": device,
         "Initial:": str(initial),
         "Final:": str(final),
@@ -289,7 +298,7 @@ def _handle_new_neb(output_dir, initial, final, *, num_images, interp_fmax,
         initial=atoms_initial, final=atoms_final,
         num_images=num_images, interp_fmax=interp_fmax,
         interp_steps=interp_steps, fmax=fmax, mlip=mlip,
-        uma_task=uma_task, output_dir=output_dir,
+        uma_task=uma_task, mace_head=mace_head, output_dir=output_dir,
         relax_atoms=relax_indices, logfile=log, device=device,
     )
 
@@ -320,6 +329,7 @@ def run(
     fmax: float = typer.Option(None, help="Final NEB force threshold"),
     mlip: str = typer.Option(None, help=MLIP_HELP),
     uma_task: str = typer.Option(None, help=UMA_TASK_HELP),
+    mace_head: str = typer.Option(None, help=MACE_HEAD_HELP),
     relax_atoms: str = typer.Option(None, help="Comma-separated list of atom indices to relax (e.g. '0,1,5'). If set, others are fixed."),
     log: str = typer.Option(None, help="Name for the NEB iteration log file (default: neb.log)"),
     k: float = typer.Option(None, help="Spring constant for NEB"),
@@ -349,7 +359,8 @@ def run(
             raise typer.Exit(code=1)
 
         neb_obj, params = _handle_restart(
-            output_dir, mlip=mlip, uma_task=uma_task, fmax=fmax, log=log,
+            output_dir, mlip=mlip, uma_task=uma_task, mace_head=mace_head,
+            fmax=fmax, log=log,
             k=k, climb=climb, neb_optimizer=neb_optimizer,
             neb_max_steps=neb_max_steps, device=device,
         )
@@ -359,7 +370,7 @@ def run(
             output_dir, initial, final,
             num_images=num_images, interp_fmax=interp_fmax,
             interp_steps=interp_steps, fmax=fmax, mlip=mlip,
-            uma_task=uma_task, log=log, k=k, climb=climb,
+            uma_task=uma_task, mace_head=mace_head, log=log, k=k, climb=climb,
             neb_optimizer=neb_optimizer, neb_max_steps=neb_max_steps,
             optimize_endpoints=optimize_endpoints, endpoint_fmax=endpoint_fmax,
             endpoint_optimizer=endpoint_optimizer,

--- a/src/mlip_platform/cli/commands/optimize.py
+++ b/src/mlip_platform/cli/commands/optimize.py
@@ -96,6 +96,8 @@ def run(
         f.write("Geometry Optimization Parameters\n")
         f.write("=================================\n")
         f.write(f"MLIP model:        {mlip}\n")
+        if mlip.startswith("uma-"):
+            f.write(f"UMA task:          {uma_task}\n")
         if mlip.startswith("mace-mh-"):
             f.write(f"MACE head:         {mace_head}\n")
         f.write(f"Device:            {device}\n")

--- a/src/mlip_platform/core/neb.py
+++ b/src/mlip_platform/core/neb.py
@@ -47,6 +47,8 @@ class CustomNEB:
         MLIP model name.
     uma_task : str
         Task name for UMA models.
+    mace_head : str
+        Head name for multi-head MACE foundation models (mace-mh-*).
     output_dir : str or Path
         Output directory for results.
     relax_atoms : list[int] or None
@@ -68,6 +70,7 @@ class CustomNEB:
         fmax: float = 0.05,
         mlip: str = "7net-mf-ompa",
         uma_task: str = "omat",
+        mace_head: str = "omat_pbe",
         output_dir: str | Path = ".",
         relax_atoms: Optional[list[int]] = None,
         logfile: str = "neb.log",
@@ -82,6 +85,7 @@ class CustomNEB:
         self.fmax = fmax
         self.mlip = mlip
         self.uma_task = uma_task
+        self.mace_head = mace_head
         self.device = device
         self.output_dir = Path(output_dir)
         self.output_dir.mkdir(parents=True, exist_ok=True)
@@ -124,6 +128,7 @@ class CustomNEB:
         key_parsers = {
             "MLIP model": ("mlip", str),
             "UMA task": ("uma_task", str),
+            "MACE head": ("mace_head", str),
             "Device": ("device", str),
             "Initial": ("initial", str),
             "Final": ("final", str),
@@ -186,6 +191,7 @@ class CustomNEB:
         output_dir: str | Path = ".",
         mlip: Optional[str] = None,
         uma_task: Optional[str] = None,
+        mace_head: Optional[str] = None,
         fmax: Optional[float] = None,
         logfile: Optional[str] = None,
         k: Optional[float] = None,
@@ -251,6 +257,7 @@ class CustomNEB:
             mlip = original_mlip
 
         uma_task = uma_task or params.get("uma_task", "omat")
+        mace_head = mace_head or params.get("mace_head", "omat_pbe")
         fmax = fmax if fmax is not None else params["fmax"]
         logfile = logfile or params.get("log", "neb.log")
         device = device if device is not None else params.get("device", "cpu")
@@ -265,6 +272,7 @@ class CustomNEB:
         instance.fmax = fmax
         instance.mlip = mlip
         instance.uma_task = uma_task
+        instance.mace_head = mace_head
         instance.device = device
         instance.output_dir = output_dir
         instance.logfile = logfile
@@ -286,7 +294,8 @@ class CustomNEB:
     # Calculator
     # ------------------------------------------------------------------
 
-    def setup_calculator(self, model: Optional[str] = None, uma_task: Optional[str] = None):
+    def setup_calculator(self, model: Optional[str] = None, uma_task: Optional[str] = None,
+                         mace_head: Optional[str] = None):
         """Create and return an MLIP calculator.
 
         Parameters
@@ -295,6 +304,9 @@ class CustomNEB:
             Model name (default: ``self.mlip``).
         uma_task : str, optional
             UMA task name (default: ``self.uma_task``).
+        mace_head : str, optional
+            Head name for multi-head MACE foundation models (mace-mh-*)
+            (default: ``self.mace_head``).
 
         Returns
         -------
@@ -302,6 +314,7 @@ class CustomNEB:
         """
         model = model or self.mlip
         uma_task = uma_task or self.uma_task
+        mace_head = mace_head or getattr(self, "mace_head", "omat_pbe")
 
         device = getattr(self, "device", "cpu")
 
@@ -311,6 +324,11 @@ class CustomNEB:
         elif model == "mace":
             from mace.calculators import mace_mp
             return mace_mp(model="medium", device=device)
+        elif model.startswith("mace-mh-"):
+            from mace.calculators import MACECalculator
+            from mlip_platform.cli.utils import _ensure_mace_foundation_checkpoint
+            ckpt = _ensure_mace_foundation_checkpoint(model)
+            return MACECalculator(model_paths=ckpt, device=device, head=mace_head)
         elif model.startswith("uma-"):
             from fairchem.core import FAIRChemCalculator, pretrained_mlip
             predictor = pretrained_mlip.get_predict_unit(model, device=device)


### PR DESCRIPTION
## Summary

The optimize parameter log was dropping the UMA task, and neither `neb` nor `autoneb` supported or logged the MACE head for multi-head foundation models (`mace-mh-*`). NEB's calculator factory also raised `"Unknown model"` for `mace-mh-*` tags, so those models could not run under NEB/AutoNEB at all.

This brings all four commands to parity — each now records the model head/task consistently.

| Command | UMA task | MACE head |
|---|---|---|
| `optimize` | logged ✓ (fixed) | logged ✓ |
| `md` | logged ✓ | logged ✓ |
| `neb` | select + log + restart ✓ | select + log + restart ✓ (new) |
| `autoneb` | select + log ✓ | select + log ✓ (new) |

## Changes

- **optimize** — log `UMA task` in `opt_params.txt` (matches `md`).
- **core/neb** — add `mace_head` to `CustomNEB.__init__`, restart parsing (`_parse_parameters_file`), and `load_from_restart`; add a `mace-mh-*` branch to `setup_calculator` (previously raised `"Unknown model"`).
- **neb** — add `--mace-head` option, thread through the new-run and restart paths, echo it at runtime, and log it in `neb_parameters.txt`.
- **autoneb** — add `--mace-head` option, log it in `autoneb_parameters.txt`, pass it to `CustomNEB`.

## Testing

- `test_core_neb.py`, `test_neb_restart.py`, `test_neb_constrained.py`, `test_neb_mace.py` and related: **18 passed, 2 skipped** (skips are env-gated, unrelated).
- Verified MACE-head round-trip write/parse on restart.
- All existing `CustomNEB(...)` callers use keyword args, so inserting `mace_head` is non-breaking.

🤖 Generated with [Claude Code](https://claude.com/claude-code)