### PR TITLE
feat(optimize): also write CONTCAR for DFT restart continuity

### DIFF
--- a/docs/OUTPUTS.md
+++ b/docs/OUTPUTS.md
@@ -26,9 +26,10 @@ This is not always the same directory the user is sitting in. `optimize` and `md
 | `opt_convergence.csv` | CSV | columns: `step`, `energy(eV)`, `fmax(eV/A)` |
 | `opt_convergence.png` | PNG | Energy and fmax vs step |
 | `opt_final.vasp` | VASP POSCAR (vasp5, direct) | Final relaxed structure |
+| `CONTCAR` | VASP POSCAR (vasp5, direct) | Copy of the final relaxed structure, named so a follow-up DFT run (e.g. managed by asetools) can restart from this directory |
 | `opt_params.txt` | plain text, key/value | Echo of run parameters (MLIP, optimizer, fmax, max_steps, etc.) |
 
-If you change `--logfile <name>.log`, the convergence CSV / PNG and final POSCAR are renamed accordingly: `<name>.log`, `<name>_convergence.csv`, `<name>_convergence.png`, `<name>_final.vasp`. The trajectory filename comes from `--trajectory`. **Two relaxations launched in the same directory will overwrite each other** unless you set `--logfile` and `--trajectory` to different names.
+If you change `--logfile <name>.log`, the convergence CSV / PNG and final POSCAR are renamed accordingly: `<name>.log`, `<name>_convergence.csv`, `<name>_convergence.png`, `<name>_final.vasp`. The `CONTCAR` filename is fixed (it does not follow `--logfile`). The trajectory filename comes from `--trajectory`. **Two relaxations launched in the same directory will overwrite each other** unless you set `--logfile` and `--trajectory` to different names.
 
 ---
 

--- a/src/mlip_platform/core/optimize.py
+++ b/src/mlip_platform/core/optimize.py
@@ -99,6 +99,9 @@ def run_optimization(
     csv_file = output_path / f"{logfile_stem}_convergence.csv"
     convergence_plot = output_path / f"{logfile_stem}_convergence.png"
     final_structure = output_path / f"{logfile_stem}_final.vasp"
+    # CONTCAR mirror of the final structure so a follow-up DFT run managed by
+    # asetools can restart from this directory (it reads OUTCAR or CONTCAR).
+    contcar_file = output_path / "CONTCAR"
 
     optimizer_name = optimizer.lower()
     if optimizer_name not in OPTIMIZER_MAP:
@@ -146,6 +149,7 @@ def run_optimization(
                 converged, opt.nsteps, final_energy, final_fmax)
 
     write(str(final_structure), atoms, format="vasp")
+    write(str(contcar_file), atoms, format="vasp")
 
     df = pd.DataFrame(log_data)
     df.to_csv(csv_file, index=False)

--- a/tests/test_core_optimize.py
+++ b/tests/test_core_optimize.py
@@ -31,6 +31,7 @@ class TestOptimizationConverges:
         assert (tmp_workdir / "opt_convergence.csv").exists()
         assert (tmp_workdir / "opt_convergence.png").exists()
         assert (tmp_workdir / "opt_final.vasp").exists()
+        assert (tmp_workdir / "CONTCAR").exists()
 
     def test_convergence_csv_has_data(self, tmp_workdir):
         import pandas as pd


### PR DESCRIPTION
## What

The optimization routine now writes a fixed-name `CONTCAR` alongside the existing `<logfile>_final.vasp`.

## Why

If a relaxation directory is linked to a follow-up DFT calculation, the asetools manager can pick up where the MLIP optimization left off — it restarts from either an `OUTCAR` or a `CONTCAR`. Emitting a `CONTCAR` makes that handoff work without manual renaming.

## Notes

- `CONTCAR` is written from the same final `atoms` and in the same `format="vasp"` (vasp5, direct) as `opt_final.vasp`.
- The name is **fixed** — it does not follow `--logfile`, since asetools looks for a literal `CONTCAR`. Two relaxations in the same directory will overwrite each other's `CONTCAR`.
- Contains positions/cell only (POSCAR format), no velocities — fine for restarting a static/relax DFT job.

## Verification

`tests/test_core_optimize.py` updated to assert `CONTCAR` exists; test passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)