### PR TITLE
ci: tests workflow with diff-coverage gate + weekly quality checks

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,35 @@
+name: Tests
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    env:
+      MPLBACKEND: Agg
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          # Full history: diff-cover compares against origin/main.
+          fetch-depth: 0
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install package with dev deps
+        run: |
+          python -m pip install --upgrade pip
+          # PyPI's "asetools" is an unrelated package; install the real one from GitHub.
+          pip install git+https://github.com/manuelarcer/asetools.git
+          pip install -e ".[dev]"
+
+      - name: Run test suite with coverage
+        run: pytest --cov=mlip_platform --cov-report=xml
+
+      - name: Diff coverage gate (>= 90% on changed lines)
+        run: |
+          git fetch origin main
+          diff-cover coverage.xml --compare-branch=origin/main --fail-under=90 --exclude setup.py --exclude "scripts/*"

--- a/.github/workflows/weekly.yml
+++ b/.github/workflows/weekly.yml
@@ -1,0 +1,72 @@
+name: Weekly quality checks
+
+on:
+  schedule:
+    - cron: "0 22 * * 0"  # Mondays 06:00 SGT (UTC+8)
+  workflow_dispatch: {}
+
+jobs:
+  weekly:
+    runs-on: ubuntu-latest
+    env:
+      MPLBACKEND: Agg
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install package with dev deps
+        run: |
+          python -m pip install --upgrade pip
+          # PyPI's "asetools" is an unrelated package; install the real one from GitHub.
+          pip install git+https://github.com/manuelarcer/asetools.git
+          pip install -e ".[dev]"
+
+      - name: Dependency vulnerability audit (report only, no upgrades)
+        run: |
+          echo "# Weekly quality summary ($(date -u +%F))" > summary.md
+          echo "## pip-audit" >> summary.md
+          pip-audit --format markdown >> summary.md 2>&1 || echo "pip-audit reported findings (see above)" >> summary.md
+
+      - name: Determine modules changed in the last 7 days
+        id: scope
+        # The handoff's literal `git diff --name-only HEAD@{7.days.ago}` relies
+        # on the reflog, which is empty in a fresh CI clone. Same semantics via
+        # commit history: diff against the last commit older than 7 days.
+        run: |
+          BASE=$(git rev-list -1 --before="7 days ago" origin/main || true)
+          if [ -z "$BASE" ]; then
+            echo "No commit older than 7 days; skipping mutation testing." | tee -a summary.md
+            echo "paths=" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          CHANGED=$(git diff --name-only "$BASE"..HEAD -- 'src/mlip_platform/**/*.py' | tr '\n' ',' | sed 's/,$//')
+          echo "Changed source modules (7 days): ${CHANGED:-none}" | tee -a summary.md
+          echo "paths=$CHANGED" >> "$GITHUB_OUTPUT"
+
+      - name: Mutation testing (scoped - full-repo runs not permitted)
+        if: steps.scope.outputs.paths != ''
+        # Surviving mutants are findings for a human, not a red X; the summary
+        # artifact carries them.
+        run: |
+          echo "## mutmut survivors" >> summary.md
+          mutmut run \
+            --paths-to-mutate "${{ steps.scope.outputs.paths }}" \
+            --tests-dir tests \
+            --runner "python -m pytest -x -q -m 'not slow'" \
+            || true
+          mutmut results >> summary.md 2>&1 || true
+
+      - name: Publish summary
+        if: always()
+        run: cat summary.md >> "$GITHUB_STEP_SUMMARY"
+
+      - uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: weekly-quality-summary
+          path: summary.md

--- a/setup.py
+++ b/setup.py
@@ -17,6 +17,17 @@ setup(
         "scipy",
         "asetools",
     ],
+    extras_require={
+        "dev": [
+            "pytest",
+            "pytest-cov",
+            "diff-cover",
+            # mutmut 3.x dropped the --paths-to-mutate CLI flag and requires
+            # pyproject.toml config; this repo has no pyproject.toml.
+            "mutmut>=2.4,<3.0",
+            "pip-audit",
+        ],
+    },
     classifiers=[
         "Development Status :: 3 - Alpha",
         "Intended Audience :: Science/Research",


### PR DESCRIPTION
Adds CI infrastructure per the test-quality handoff:

- `.github/workflows/tests.yml` — on every push/PR: install (asetools from GitHub — the PyPI name is an unrelated package), `pytest --cov`, then `diff-cover --fail-under=90` against `origin/main`. Only changed lines count; legacy coverage is irrelevant.
- `.github/workflows/weekly.yml` — Mondays 06:00 SGT: `pip-audit` (report-only), `mutmut` scoped to modules changed in the last 7 days (skipped if none; full-repo runs not permitted), summary uploaded as artifact.
- `setup.py` — new `[dev]` extra: pytest, pytest-cov, diff-cover, mutmut<3.0, pip-audit.

Deviation from handoff: the 7-day scope uses `git rev-list -1 --before="7 days ago" origin/main` instead of `HEAD@{7.days.ago}` — the reflog is empty in a fresh CI clone, so the literal command always fails there. Semantics are the same.

🤖 Generated with [Claude Code](https://claude.com/claude-code)