### PR TITLE
test: repair pre-existing suite failures (run_md kwargs + typer.Exit matching)

### DIFF
--- a/tests/test_cli_utils.py
+++ b/tests/test_cli_utils.py
@@ -3,7 +3,6 @@ import pytest
 from unittest.mock import patch
 
 import typer
-from click.exceptions import Exit as ClickExit
 
 from mlip_platform.cli.utils import (
     detect_mlip,
@@ -18,14 +17,13 @@ from mlip_platform.cli.utils import (
 
 
 class TestDetectMlip:
+    @patch("mlip_platform.cli.utils.FAIRCHEM_AVAILABLE", True)
     def test_returns_string(self):
-        # Should return a string regardless of what's available
-        try:
-            result = detect_mlip()
-            assert isinstance(result, str)
-        except SystemExit:
-            # No MLIP installed — that's also a valid outcome
-            pass
+        # With a backend available, detect_mlip returns a non-empty model tag.
+        # Mocked so the result does not depend on what is installed in the env.
+        result = detect_mlip()
+        assert isinstance(result, str)
+        assert result
 
     @patch("mlip_platform.cli.utils.FAIRCHEM_AVAILABLE", True)
     def test_prefers_uma(self):
@@ -54,7 +52,7 @@ class TestDetectMlip:
     @patch("mlip_platform.cli.utils.MACE_AVAILABLE", False)
     @patch("mlip_platform.cli.utils.CHGNET_AVAILABLE", False)
     def test_none_available_raises(self):
-        with pytest.raises((SystemExit, ClickExit)):
+        with pytest.raises(typer.Exit):
             detect_mlip()
 
 
@@ -63,27 +61,27 @@ class TestValidateMlip:
         validate_mlip("auto")  # should not raise
 
     def test_unknown_mlip_raises(self):
-        with pytest.raises((SystemExit, ClickExit)):
+        with pytest.raises(typer.Exit):
             validate_mlip("nonexistent-model")
 
     @patch("mlip_platform.cli.utils.MACE_AVAILABLE", False)
     def test_mace_unavailable_raises(self):
-        with pytest.raises((SystemExit, ClickExit)):
+        with pytest.raises(typer.Exit):
             validate_mlip("mace")
 
     @patch("mlip_platform.cli.utils.SEVENN_AVAILABLE", False)
     def test_sevenn_unavailable_raises(self):
-        with pytest.raises((SystemExit, ClickExit)):
+        with pytest.raises(typer.Exit):
             validate_mlip("7net-mf-ompa")
 
     @patch("mlip_platform.cli.utils.FAIRCHEM_AVAILABLE", False)
     def test_uma_unavailable_raises(self):
-        with pytest.raises((SystemExit, ClickExit)):
+        with pytest.raises(typer.Exit):
             validate_mlip("uma-s-1p1")
 
     @patch("mlip_platform.cli.utils.CHGNET_AVAILABLE", False)
     def test_chgnet_unavailable_raises(self):
-        with pytest.raises((SystemExit, ClickExit)):
+        with pytest.raises(typer.Exit):
             validate_mlip("chgnet")
 
     @patch("mlip_platform.cli.utils.CHGNET_AVAILABLE", True)
@@ -118,13 +116,13 @@ class TestParseRelaxAtoms:
         assert result == [0, 1, 5]
 
     def test_invalid_format_raises(self):
-        with pytest.raises((SystemExit, ClickExit)):
+        with pytest.raises(typer.Exit):
             parse_relax_atoms("a,b,c", num_atoms=10)
 
     def test_out_of_range_raises(self):
-        with pytest.raises((SystemExit, ClickExit)):
+        with pytest.raises(typer.Exit):
             parse_relax_atoms("0,1,100", num_atoms=10)
 
     def test_negative_index_raises(self):
-        with pytest.raises((SystemExit, ClickExit)):
+        with pytest.raises(typer.Exit):
             parse_relax_atoms("-1,0,1", num_atoms=10)

--- a/tests/test_core_md.py
+++ b/tests/test_core_md.py
@@ -53,7 +53,7 @@ class TestRunMd:
         atoms.calc = EMT()
 
         run_md(
-            atoms, ensemble="nve", steps=5, interval=1,
+            atoms, ensemble="nve", steps=5, log_interval=1, traj_interval=1,
             output_dir=tmp_workdir,
         )
 
@@ -68,7 +68,7 @@ class TestRunMd:
 
         run_md(
             atoms, ensemble="nvt", thermostat="langevin",
-            temperature=300, steps=5, interval=1,
+            temperature=300, steps=5, log_interval=1, traj_interval=1,
             output_dir=tmp_workdir,
         )
 
@@ -84,7 +84,7 @@ class TestRunMd:
         atoms.calc = EMT()
         run_md(
             atoms, ensemble="nvt", thermostat="langevin",
-            temperature=100, steps=10, interval=2,
+            temperature=100, steps=10, log_interval=2, traj_interval=2,
             output_dir=tmp_workdir, friction=0.05,
         )
         import pandas as pd
@@ -96,7 +96,7 @@ class TestRunMd:
         atoms2.calc = EMT()
         run_md(
             atoms2, ensemble="nvt", thermostat="langevin",
-            temperature=100, steps=10, interval=2,
+            temperature=100, steps=10, log_interval=2, traj_interval=2,
             output_dir=tmp_workdir, friction=0.05, resume=True,
         )
 
@@ -114,6 +114,6 @@ class TestRunMd:
         atoms.calc = EMT()
         with pytest.raises(FileNotFoundError, match="Cannot resume"):
             run_md(
-                atoms, ensemble="nvt", steps=5, interval=1,
+                atoms, ensemble="nvt", steps=5, log_interval=1, traj_interval=1,
                 output_dir=tmp_workdir, resume=True,
             )

--- a/tests/test_integration_uma.py
+++ b/tests/test_integration_uma.py
@@ -73,7 +73,7 @@ class TestMDUMA:
         atoms, _ = uma_atoms
         run_md(
             atoms, ensemble="nvt", thermostat="langevin",
-            temperature=300, steps=10, interval=5,
+            temperature=300, steps=10, log_interval=5, traj_interval=5,
             output_dir=tmp_workdir,
         )
         assert (tmp_workdir / "md.traj").exists()


### PR DESCRIPTION
`main`'s test suite is red on a clean runner (visible in CI for PRs #25/#26). This repairs both failure classes so the new CI `Tests` check can pass; it is the prerequisite that unblocks the diff-coverage gate on the infrastructure PRs.

**1. Stale `run_md` kwargs (4–5 failures, everywhere including local).** Commit f023ff1 split `run_md`'s single `interval` param into `log_interval`/`traj_interval` but didn't update callers. Fixed 6 call sites (`tests/test_core_md.py`, `tests/test_integration_uma.py`), setting both new knobs to the old single value to preserve the original logging/trajectory cadence.

**2. Exception-type mismatch (CI-only, ~9 failures).** `tests/test_cli_utils.py` caught `click.exceptions.Exit` imported from top-level `click`, but the code raises `typer.Exit`. Those are the same class only when `typer` does not vendor its own `click` — true locally (typer 0.20, `typer.Exit is click.exceptions.Exit`), false on the CI typer version, where the raised `typer._click.exceptions.Exit` slips past `pytest.raises`. Now matches `typer.Exit` directly (the exact symbol raised), immune to click-vendoring across typer versions. `test_returns_string` also caught `SystemExit` (which `typer.Exit` is not a subclass of) and depended on an MLIP being installed; rewritten to mock `FAIRCHEM_AVAILABLE` and assert a non-empty tag, so it is deterministic on any environment.

Full suite locally: 82 passed, 6 skipped, 0 failed. No source (`src/`) changes — tests only. CI here provides the clean, no-MLIP verification that the local run cannot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)