### PR TITLE
Docs sync + MACE-preferred fallback + opt-in plotting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,15 @@ All notable changes to this project are documented here. Format follows [Keep a 
 - `build_calculator()` in `mlip_platform.cli.utils`: builds and returns an ASE calculator without attaching it, so the loaded model can be reused across many structures. `setup_calculator()` is now a thin build-and-attach wrapper around it.
 - `optimize run` / `optimize batch` now also write a fixed-name `CONTCAR` (copy of the final relaxed structure) so a follow-up DFT run managed by asetools can restart from the directory.
 - `optimize run` / `optimize batch` `--no-plot` flag: skip the per-structure `*_convergence.png` figure (the `*_convergence.csv` is still written). The matplotlib figure/save is per-structure IO that dominates short relaxations, so disabling it materially speeds up large batches — measured ~3x on frozen-surface site scans (BFGS, single-adsorbate), where the plot cost more per job than the model load. Threaded through `run_optimization(plot=...)`.
+- `neb run --device {cpu|cuda}`: run NEB on GPU. Defaults to `cpu` (unlike `optimize`/`md`, which default to `auto`); pass `--device cuda` for GPU runs. The device is recorded in `neb_parameters.txt` and honored on `--restart`.
+- `neb run` support for multi-head MACE foundation models via `--mace-head` (same head values as the other commands); the resolved MACE head is logged in the NEB parameter file.
+- CI: `tests.yml` GitHub Actions workflow runs the unit suite with a diff-coverage gate (>= 90% on changed lines) on every push/PR, plus a `weekly.yml` scheduled quality-check run. New baseline characterization tests (golden outputs + physics invariants) guard against regressions.
+
+### Changed
+
+- NEB now uses ASE's `improvedtangent` tangent method instead of the older default (`aseneb`), which improves convergence on curved reaction paths.
+- All parameter files (`opt_params.txt`, `md_params.txt`, `neb_parameters.txt`) now record the resolved MLIP head/task, so a run's provenance is fully captured in its parameter file.
+- `md_energy.png` plots kinetic energy on a twin right axis for readability alongside total/potential energy.
 
 ## [0.3.0] - 2026-05-08
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,16 +9,18 @@ All notable changes to this project are documented here. Format follows [Keep a 
 - `optimize batch`: relax a series of structures in one process, loading the MLIP model **only once** and reusing it across every relaxation (avoids the per-run model-load cost). Discovers one input structure per immediate subdirectory of `--parent` (default `--input-name '*.vasp'`; the platform's own `*_final.vasp` outputs are ignored), relaxes each in place, continues past failures, and writes a `batch_summary.csv` into `--parent`. Supports `--skip-existing` to resume a partial batch.
 - `build_calculator()` in `mlip_platform.cli.utils`: builds and returns an ASE calculator without attaching it, so the loaded model can be reused across many structures. `setup_calculator()` is now a thin build-and-attach wrapper around it.
 - `optimize run` / `optimize batch` now also write a fixed-name `CONTCAR` (copy of the final relaxed structure) so a follow-up DFT run managed by asetools can restart from the directory.
-- `optimize run` / `optimize batch` `--no-plot` flag: skip the per-structure `*_convergence.png` figure (the `*_convergence.csv` is still written). The matplotlib figure/save is per-structure IO that dominates short relaxations, so disabling it materially speeds up large batches — measured ~3x on frozen-surface site scans (BFGS, single-adsorbate), where the plot cost more per job than the model load. Threaded through `run_optimization(plot=...)`.
+- `--plot / --no-plot` flag on `optimize run`, `optimize batch`, `md run`, and `neb run`. Plotting is now **opt-in**: with `--plot` the command writes its PNG figures; without it (the default) only the CSVs are written. Threaded through `run_optimization(plot=...)`, `run_md(plot=...)`, and `CustomNEB.run_neb(plot=...)`.
 - `neb run --device {cpu|cuda}`: run NEB on GPU. Defaults to `cpu` (unlike `optimize`/`md`, which default to `auto`); pass `--device cuda` for GPU runs. The device is recorded in `neb_parameters.txt` and honored on `--restart`.
 - `neb run` support for multi-head MACE foundation models via `--mace-head` (same head values as the other commands); the resolved MACE head is logged in the NEB parameter file.
 - CI: `tests.yml` GitHub Actions workflow runs the unit suite with a diff-coverage gate (>= 90% on changed lines) on every push/PR, plus a `weekly.yml` scheduled quality-check run. New baseline characterization tests (golden outputs + physics invariants) guard against regressions.
 
 ### Changed
 
+- **Plotting is now opt-in across `optimize`, `md`, and `neb`.** Previously these commands always wrote PNG figures (`optimize` had a `--no-plot` opt-out; `md`/`neb` had no way to disable it). Now no PNG is written unless `--plot` is passed. The CSV data (`*_convergence.csv`, `md_energy.csv`, `neb_convergence.csv`, `neb_data.csv`) is always written, so nothing is lost — figures can be regenerated from it. Motivation: the figure/save is IO that dominates short runs (measured ~3x speedup on frozen-surface site scans). The old `--no-plot` still works as the off side of `--plot/--no-plot`, so existing scripts are unaffected.
+- **Auto-detection order changed to UMA → MACE → SevenNet → CHGNet** (was UMA → SevenNet → MACE → CHGNet). UMA is still preferred when installed, but MACE is now the preferred fallback ahead of SevenNet/CHGNet: UMA is gated on Hugging Face and unusable without an access request, whereas `pip install mace-torch` gives a working model immediately. A fresh environment therefore lands on a usable default.
 - NEB now uses ASE's `improvedtangent` tangent method instead of the older default (`aseneb`), which improves convergence on curved reaction paths.
 - All parameter files (`opt_params.txt`, `md_params.txt`, `neb_parameters.txt`) now record the resolved MLIP head/task, so a run's provenance is fully captured in its parameter file.
-- `md_energy.png` plots kinetic energy on a twin right axis for readability alongside total/potential energy.
+- `md_energy.png` plots kinetic energy on a twin right axis for readability alongside total/potential energy (when `--plot` is used).
 
 ## [0.3.0] - 2026-05-08
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -78,6 +78,15 @@ pytestmark = pytest.mark.uma   # entire module gated on fairchem-core
 5. Add an entry to `CHANGELOG.md` under `[Unreleased]` describing the user-visible change. Follow the existing structure (Added / Changed / Fixed / Removed / Deprecated).
 6. Run the unit suite locally before pushing: `pytest -m "not uma and not mace and not sevenn"`.
 
+## Continuous integration
+
+Every push and pull request runs `.github/workflows/tests.yml`:
+
+- The unit suite runs under coverage (`pytest --cov=mlip_platform --cov-report=xml`).
+- A **diff-coverage gate** requires **>= 90% coverage on the lines your PR changes** (`diff-cover coverage.xml --compare-branch=origin/main --fail-under=90`, excluding `setup.py` and `scripts/*`). A PR that adds untested code will fail here — add tests for new lines before pushing.
+
+A separate scheduled workflow (`.github/workflows/weekly.yml`) runs broader quality checks weekly; you do not need to trigger it for a PR.
+
 ## Versioning and releases
 
 Versioning follows [Semantic Versioning](https://semver.org/). The version lives in `setup.py`. To cut a release:

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Supports **UMA** (FAIRChem), **SevenNet** (7net), and **MACE** models with autom
 ## Key Features
 
 - Unified CLI commands: `optimize run`, `md run`, `neb run`, `autoneb run`
-- Auto-detection of available MLIP models (UMA > SevenNet > MACE)
+- Auto-detection of available MLIP models (UMA > MACE > SevenNet > CHGNet)
 - UMA model support with multiple task types (OMat, OC20, OMol, ODAC)
 - MACE multi-head foundation models (`mace-mh-*`) with selectable heads (`omat_pbe`, `oc20_usemppbe`, `matpes_r2scan`, …)
 - GPU/CPU selection via `--device` (`auto`/`cuda`/`cpu`) on all run commands
@@ -24,7 +24,7 @@ Supports **UMA** (FAIRChem), **SevenNet** (7net), and **MACE** models with autom
 - Configurable thermostats (Langevin, Nose-Hoover, Berendsen) and barostats (MTK NPT, Berendsen NPT)
 - NEB with IDPP interpolation, restart support, and highly-constrained mode
 - AutoNEB with dynamic image insertion
-- Automated plotting and CSV output for all simulations
+- CSV output for all simulations; PNG plots are opt-in via `--plot` (CSVs are always written)
 - Lazy imports for fast CLI startup
 - Pytest-based test suite with EMT-based unit tests and MLIP integration tests
 
@@ -48,20 +48,20 @@ pip install -e .
 3. **Install MLIP models** (choose one or more)
 
 ```bash
-# UMA models (FAIRChem) - Recommended; gated on Hugging Face
+# MACE - readily usable, no access request (good default for a fresh setup)
+pip install mace-torch
+
+# UMA models (FAIRChem) - most accurate, but gated on Hugging Face
 pip install fairchem-core
 
 # SevenNet
 pip install sevenn
 
-# MACE
-pip install mace-torch
-
 # CHGNet
 pip install chgnet
 ```
 
-> **Note**: Models can coexist in the same environment. With `--mlip auto` (the default), the CLI picks the first available in the order **UMA → SevenNet → MACE → CHGNet**, or you can pass `--mlip <name>` to force a specific one. UMA additionally requires Hugging Face access — see [UMA_USAGE_GUIDE.md](docs/UMA_USAGE_GUIDE.md#2-hugging-face-access).
+> **Note**: Models can coexist in the same environment. With `--mlip auto` (the default), the CLI picks the first available in the order **UMA → MACE → SevenNet → CHGNet**, or you can pass `--mlip <name>` to force a specific one. UMA is preferred when installed (it is the most accurate), but it is gated on Hugging Face and unusable without an access request — so MACE is placed ahead of SevenNet/CHGNet as the readily-usable fallback. A fresh environment with only `pip install mace-torch` lands on a working model with no access request. UMA's Hugging Face setup is covered in [UMA_USAGE_GUIDE.md](docs/UMA_USAGE_GUIDE.md#2-hugging-face-access).
 
 ### Windows Setup
 
@@ -82,10 +82,11 @@ The package installs the following entry points:
 
 These apply to `optimize`, `md`, `neb`, `autoneb`, and `benchmark`:
 
-- `--mlip`: Model tag. `auto` (default) picks the first installed in order **UMA → SevenNet → MACE → CHGNet**, or pass an explicit tag: any `uma-*` (e.g. `uma-s-1p2`), `mace` (MACE-MP-0), `mace-mh-1` (multi-head foundation), `7net-mf-ompa`, `chgnet`.
+- `--mlip`: Model tag. `auto` (default) picks the first installed in order **UMA → MACE → SevenNet → CHGNet** (UMA preferred when present, MACE as the readily-usable fallback), or pass an explicit tag: any `uma-*` (e.g. `uma-s-1p2`), `mace` (MACE-MP-0), `mace-mh-1` (multi-head foundation), `7net-mf-ompa`, `chgnet`.
 - `--uma-task`: Task head for UMA models — `omat` (default, bulk inorganic), `oc20` (catalysis/surfaces), `omol` (molecules), `odac`. Ignored for non-UMA models.
 - `--mace-head`: Head for multi-head MACE models (`mace-mh-*`) — `omat_pbe` (default), `oc20_usemppbe`, `matpes_r2scan`, `mp_pbe_refit_add`, `omol`, `spice_wB97M`. Ignored for plain `mace`.
 - `--device`: `auto` (default; cuda if available, else cpu), `cuda`, or `cpu`. On multi-GPU nodes set `CUDA_VISIBLE_DEVICES` to choose the GPU. (`neb` is the exception: it defaults to `cpu`, so pass `--device cuda` explicitly for GPU NEB runs.)
+- `--plot / --no-plot`: write PNG figures of the results. **Off by default** (plotting is opt-in) — the CSV data is always written, so pass `--plot` only when you want the figures. Applies to `optimize`, `md`, and `neb`.
 
 **Example (multi-head MACE on a catalysis surface, forced to GPU):**
 ```bash
@@ -103,7 +104,7 @@ optimize run --structure path/to/structure.vasp
 - `--fmax`: Force convergence threshold in eV/Å (default: `0.05`)
 - `--max-steps`: Maximum optimization steps (default: `200`)
 - `--relax-cell`: Also relax the simulation cell (VASP ISIF=3-equivalent), wrapping the atoms in ASE's `FrechetCellFilter`. Off by default (positions only).
-- `--no-plot`: Skip the per-structure `*_convergence.png` figure (the `*_convergence.csv` is still written). The plot is per-structure IO that dominates short relaxations, so disabling it materially speeds up large batches.
+- `--plot`: also write the `*_convergence.png` figure (off by default; the `*_convergence.csv` is always written). The plot is per-structure IO that dominates short relaxations, so it is opt-in.
 
 **Example (positions only):**
 ```bash
@@ -115,7 +116,7 @@ optimize run --structure POSCAR --mlip uma-s-1p2 --optimizer fire --fmax 0.05
 optimize run --structure POSCAR --relax-cell --optimizer fire --fmax 0.02
 ```
 
-**Outputs:** `opt.traj`, `opt.log`, `opt_convergence.csv`, `opt_convergence.png`, `opt_final.vasp`, `CONTCAR`, `opt_params.txt`
+**Outputs:** `opt.traj`, `opt.log`, `opt_convergence.csv`, `opt_final.vasp`, `CONTCAR`, `opt_params.txt` (plus `opt_convergence.png` with `--plot`)
 
 (`CONTCAR` is a copy of the final structure, named so a follow-up DFT run managed by asetools can restart from the directory.)
 
@@ -129,7 +130,7 @@ optimize batch --parent runs/ --mlip uma-s-1p2 --fmax 0.05
 
 - `--input-name`: glob for the input inside each subdir (default `*.vasp`, i.e. exactly one `.vasp` file per subdir; the platform's own `*_final.vasp` outputs are ignored). Use e.g. `POSCAR` for a fixed name.
 - `--skip-existing`: skip subdirs that already have a `CONTCAR` (resume a partial batch).
-- `--no-plot`: skip the per-structure convergence PNG for every relaxation in the batch (measured ~3x speedup on frozen-surface site scans, where the plot cost more per job than the model load).
+- `--plot`: also write the per-structure convergence PNG for every relaxation (off by default — skipping it gives a measured ~3x speedup on frozen-surface site scans, where the plot cost more per job than the model load).
 - A structure that errors or fails to converge is logged and the batch continues; results are summarized in `batch_summary.csv` written into `--parent`.
 
 ---
@@ -151,6 +152,7 @@ md run --structure path/to/structure.vasp
 - `--traj-interval`: Write a frame to `md.traj` every N steps (default: 100)
 - `--resume`: Continue an existing run — loads the last frame of `md.traj`, preserves momenta, and treats `--steps` as *additional* steps
 - `--mlip`: Model choice (default: `auto`)
+- `--plot`: also write the `md_energy` / `md_temperature` (and NPT `md_pressure` / `md_volume`) PNGs (off by default; `md_energy.csv` is always written)
 
 For the full MD parameter list, defaults, recommended values for solids, and worked examples, see [MD_REFERENCE.md](docs/MD_REFERENCE.md).
 
@@ -169,7 +171,7 @@ md run --structure POSCAR --ensemble npt --temperature 300 --pressure 0.0 --step
 md run --structure POSCAR --resume --steps 5000
 ```
 
-**Outputs:** `md.traj`, `md_energy.csv`, `md_energy.png`, `md_temperature.png`, `md_pressure.png` (NPT), `md_volume.png` (NPT), `md_params.txt`
+**Outputs:** `md.traj`, `md_energy.csv`, `md_params.txt` (with `--plot`, also `md_energy.png`, `md_temperature.png`, and for NPT `md_pressure.png` / `md_volume.png`)
 
 ---
 
@@ -189,6 +191,7 @@ neb run --initial path/to/initial.vasp --final path/to/final.vasp
 - `--optimize-endpoints / --no-optimize-endpoints`: Pre-optimize endpoints (default: enabled)
 - `--device`: Compute device for the MLIP calculator — `cpu` (default) or `cuda`. Unlike `optimize`/`md` (which default to `auto`), NEB runs on CPU unless you pass `--device cuda`.
 - `--mace-head`: Head for multi-head MACE models (`mace-mh-*`), same values as the other commands.
+- `--plot`: also write `neb_convergence.png` and `neb_energy.png` (off by default; `neb_convergence.csv` and `neb_data.csv` are always written — the CSV is usually enough to inspect the barrier).
 
 The band uses ASE's `improvedtangent` NEB tangent method (not the older default `aseneb`).
 
@@ -197,7 +200,7 @@ The band uses ASE's `improvedtangent` NEB tangent method (not the older default 
 neb run --initial POSCAR_A --final POSCAR_B --num-images 7 --fmax 0.05 --mlip uma-s-1p2
 ```
 
-**Outputs:** `A2B.traj`, `A2B_full.traj`, `neb.log`, `neb_convergence.csv`, `neb_convergence.png`, `neb_energy.png`, `neb_data.csv`, `neb_parameters.txt`, POSCAR files (`00/`, `01/`, ...)
+**Outputs:** `A2B.traj`, `A2B_full.traj`, `neb.log`, `neb_convergence.csv`, `neb_data.csv`, `neb_parameters.txt`, POSCAR files (`00/`, `01/`, ...) (with `--plot`, also `neb_convergence.png` and `neb_energy.png`)
 
 #### NEB Restart
 

--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ These apply to `optimize`, `md`, `neb`, `autoneb`, and `benchmark`:
 - `--mlip`: Model tag. `auto` (default) picks the first installed in order **UMA → SevenNet → MACE → CHGNet**, or pass an explicit tag: any `uma-*` (e.g. `uma-s-1p2`), `mace` (MACE-MP-0), `mace-mh-1` (multi-head foundation), `7net-mf-ompa`, `chgnet`.
 - `--uma-task`: Task head for UMA models — `omat` (default, bulk inorganic), `oc20` (catalysis/surfaces), `omol` (molecules), `odac`. Ignored for non-UMA models.
 - `--mace-head`: Head for multi-head MACE models (`mace-mh-*`) — `omat_pbe` (default), `oc20_usemppbe`, `matpes_r2scan`, `mp_pbe_refit_add`, `omol`, `spice_wB97M`. Ignored for plain `mace`.
-- `--device`: `auto` (default; cuda if available, else cpu), `cuda`, or `cpu`. On multi-GPU nodes set `CUDA_VISIBLE_DEVICES` to choose the GPU.
+- `--device`: `auto` (default; cuda if available, else cpu), `cuda`, or `cpu`. On multi-GPU nodes set `CUDA_VISIBLE_DEVICES` to choose the GPU. (`neb` is the exception: it defaults to `cpu`, so pass `--device cuda` explicitly for GPU NEB runs.)
 
 **Example (multi-head MACE on a catalysis surface, forced to GPU):**
 ```bash
@@ -103,6 +103,7 @@ optimize run --structure path/to/structure.vasp
 - `--fmax`: Force convergence threshold in eV/Å (default: `0.05`)
 - `--max-steps`: Maximum optimization steps (default: `200`)
 - `--relax-cell`: Also relax the simulation cell (VASP ISIF=3-equivalent), wrapping the atoms in ASE's `FrechetCellFilter`. Off by default (positions only).
+- `--no-plot`: Skip the per-structure `*_convergence.png` figure (the `*_convergence.csv` is still written). The plot is per-structure IO that dominates short relaxations, so disabling it materially speeds up large batches.
 
 **Example (positions only):**
 ```bash
@@ -128,6 +129,7 @@ optimize batch --parent runs/ --mlip uma-s-1p2 --fmax 0.05
 
 - `--input-name`: glob for the input inside each subdir (default `*.vasp`, i.e. exactly one `.vasp` file per subdir; the platform's own `*_final.vasp` outputs are ignored). Use e.g. `POSCAR` for a fixed name.
 - `--skip-existing`: skip subdirs that already have a `CONTCAR` (resume a partial batch).
+- `--no-plot`: skip the per-structure convergence PNG for every relaxation in the batch (measured ~3x speedup on frozen-surface site scans, where the plot cost more per job than the model load).
 - A structure that errors or fails to converge is logged and the batch continues; results are summarized in `batch_summary.csv` written into `--parent`.
 
 ---
@@ -185,10 +187,14 @@ neb run --initial path/to/initial.vasp --final path/to/final.vasp
 - `--neb-optimizer`: Optimizer for NEB (`fire`, `mdmin`, `bfgs`, `lbfgs`)
 - `--neb-max-steps`: Maximum NEB steps
 - `--optimize-endpoints / --no-optimize-endpoints`: Pre-optimize endpoints (default: enabled)
+- `--device`: Compute device for the MLIP calculator — `cpu` (default) or `cuda`. Unlike `optimize`/`md` (which default to `auto`), NEB runs on CPU unless you pass `--device cuda`.
+- `--mace-head`: Head for multi-head MACE models (`mace-mh-*`), same values as the other commands.
+
+The band uses ASE's `improvedtangent` NEB tangent method (not the older default `aseneb`).
 
 **Example:**
 ```bash
-neb run --initial POSCAR_A --final POSCAR_B --num-images 7 --fmax 0.05 --mlip uma-s-1p1
+neb run --initial POSCAR_A --final POSCAR_B --num-images 7 --fmax 0.05 --mlip uma-s-1p2
 ```
 
 **Outputs:** `A2B.traj`, `A2B_full.traj`, `neb.log`, `neb_convergence.csv`, `neb_convergence.png`, `neb_energy.png`, `neb_data.csv`, `neb_parameters.txt`, POSCAR files (`00/`, `01/`, ...)
@@ -200,7 +206,7 @@ Resume a previous NEB calculation with optional parameter overrides:
 ```bash
 neb run --restart
 neb run --restart --fmax 0.03 --neb-max-steps 1000
-neb run --restart --mlip uma-m-1p1  # Warning: changes MLIP model
+neb run --restart --mlip mace         # Warning: changes MLIP model
 ```
 
 The restart mechanism:

--- a/docs/MD_REFERENCE.md
+++ b/docs/MD_REFERENCE.md
@@ -119,13 +119,13 @@ Every `md run` invocation writes the following to the directory containing the i
 |------|----------|
 | `md.traj` | Full ASE trajectory (every `--traj-interval` steps) |
 | `md_energy.csv` | Step, time (fs), temperature (K), total / potential / kinetic energy (eV); plus `pressure(GPa)` and `volume(A^3)` columns for NPT |
-| `md_energy.png` | Total / potential / kinetic energy vs time |
-| `md_temperature.png` | Temperature vs time, with target line for NVT/NPT |
-| `md_pressure.png` | NPT only: pressure vs time, with target line |
-| `md_volume.png` | NPT only: volume vs time |
 | `md_params.txt` | Echo of every parameter the run was launched with |
+| `md_energy.png` | Total / potential / kinetic energy vs time — **only with `--plot`** |
+| `md_temperature.png` | Temperature vs time, with target line for NVT/NPT — **only with `--plot`** |
+| `md_pressure.png` | NPT only: pressure vs time, with target line — **only with `--plot`** |
+| `md_volume.png` | NPT only: volume vs time — **only with `--plot`** |
 
-Output goes to `Path(--structure).parent`, not the current working directory.
+Plotting is opt-in: `md.traj`, `md_energy.csv`, and `md_params.txt` are always written; the PNGs require `--plot`. Output goes to `Path(--structure).parent`, not the current working directory.
 
 ---
 
@@ -177,7 +177,7 @@ md run --structure structure.vasp \
    --ensemble nve --steps 10000 --timestep 1.0
 ```
 
-Inspect `md_energy.png`: the total-energy curve should be flat. Drift is a sign that the timestep is too large or the calculator is stochastic.
+Inspect the total energy over time (plot `md_energy.csv`, or run with `--plot` to get `md_energy.png`): the total-energy curve should be flat. Drift is a sign that the timestep is too large or the calculator is stochastic.
 
 ---
 

--- a/docs/OUTPUTS.md
+++ b/docs/OUTPUTS.md
@@ -25,7 +25,7 @@ This is not always the same directory the user is sitting in. `optimize` and `md
 | `opt.traj` | ASE trajectory (binary) | Every optimizer step |
 | `opt.log` | text | ASE optimizer log (step, fmax, energy) |
 | `opt_convergence.csv` | CSV | columns: `step`, `energy(eV)`, `fmax(eV/A)` |
-| `opt_convergence.png` | PNG | Energy and fmax vs step |
+| `opt_convergence.png` | PNG | Energy and fmax vs step — **only with `--plot`** (plotting is opt-in; the CSV is always written) |
 | `opt_final.vasp` | VASP POSCAR (vasp5, direct) | Final relaxed structure |
 | `CONTCAR` | VASP POSCAR (vasp5, direct) | Copy of the final relaxed structure, named so a follow-up DFT run (e.g. managed by asetools) can restart from this directory |
 | `opt_params.txt` | plain text, key/value | Echo of run parameters (MLIP, optimizer, fmax, max_steps, etc.) |
@@ -55,11 +55,16 @@ Always written:
 |------|--------|----------|
 | `md.traj` | ASE trajectory (binary) | Every `interval` steps |
 | `md_energy.csv` | CSV | columns: `step`, `time(fs)`, `temperature(K)`, `total_energy(eV)`, `potential_energy(eV)`, `kinetic_energy(eV)` |
-| `md_energy.png` | PNG | Total / potential / kinetic energy vs time |
-| `md_temperature.png` | PNG | Temperature vs time, with target line for NVT/NPT |
 | `md_params.txt` | plain text | Echo of run parameters |
 
-NPT-only extras:
+Only with `--plot` (plotting is opt-in; the CSV above is always written):
+
+| File | Format | Contents |
+|------|--------|----------|
+| `md_energy.png` | PNG | Total / potential / kinetic energy vs time |
+| `md_temperature.png` | PNG | Temperature vs time, with target line for NVT/NPT |
+
+NPT-only extras (also require `--plot`):
 
 | File | Format | Contents |
 |------|--------|----------|
@@ -95,9 +100,9 @@ NEB run:
 | `A2B_full.traj` | ASE trajectory | All NEB iteration steps; required for `--restart` |
 | `neb.log` (or `--log` value) | text | Per-iteration log: step, fmax, current barrier |
 | `neb_convergence.csv` | CSV | columns: `step`, `fmax(eV/A)`, `barrier(eV)` |
-| `neb_convergence.png` | PNG | Two-panel: fmax vs step, barrier vs step |
+| `neb_convergence.png` | PNG | Two-panel: fmax vs step, barrier vs step — **only with `--plot`** |
 | `neb_data.csv` | CSV | One row per image: index, energy, relative energy, force info |
-| `neb_energy.png` | PNG | Smoothed energy profile across the band, barrier annotated |
+| `neb_energy.png` | PNG | Smoothed energy profile across the band, barrier annotated — **only with `--plot`** |
 | `neb_parameters.txt` | plain text | Echo of run parameters; required for `--restart` |
 | `00/POSCAR`, `01/POSCAR`, ... | VASP POSCAR | One directory per image, including endpoints |
 

--- a/docs/PYTHON_API.md
+++ b/docs/PYTHON_API.md
@@ -59,7 +59,7 @@ Auto-detection is also exposed:
 ```python
 from mlip_platform.cli.utils import detect_mlip, resolve_mlip
 
-detect_mlip()              # returns first installed: "uma-s-1p2" / "7net-mf-ompa" / "mace" / "chgnet"
+detect_mlip()              # returns first installed, in order: "uma-s-1p2" / "mace" / "7net-mf-ompa" / "chgnet"
 resolve_mlip("auto")       # detect + echo to stdout — convenience wrapper
 resolve_mlip("uma-s-1p2")  # validate availability + echo
 ```
@@ -84,7 +84,7 @@ converged = run_optimization(
     relax_cell=False,   # True → also relax the cell (VASP ISIF=3-equivalent)
     output_dir="./relaxed",
     model_name="uma-s-1p2",
-    plot=True,          # False → skip the *_convergence.png (CSV still written)
+    plot=False,         # default: no PNG. Set True to write *_convergence.png (CSV always written)
 )
 ```
 

--- a/docs/PYTHON_API.md
+++ b/docs/PYTHON_API.md
@@ -6,7 +6,8 @@ The CLI commands wrap a small set of pure-Python functions and one class. This p
 
 | Module | Public symbol | Purpose |
 |--------|---------------|---------|
-| `mlip_platform.cli.utils` | `setup_calculator(atoms, mlip, uma_task="omat", device="auto", mace_head="omat_pbe")` | Attach the right MLIP calculator to an `Atoms` object |
+| `mlip_platform.cli.utils` | `build_calculator(mlip, uma_task="omat", device="auto", mace_head="omat_pbe")` | Build and **return** an MLIP calculator (loads model weights once) without attaching it |
+| `mlip_platform.cli.utils` | `setup_calculator(atoms, mlip, uma_task="omat", device="auto", mace_head="omat_pbe")` | Attach the right MLIP calculator to an `Atoms` object (thin wrapper over `build_calculator`) |
 | `mlip_platform.cli.utils` | `detect_mlip()` / `validate_mlip(name)` / `resolve_mlip(name)` | Auto-detect / validate MLIP availability |
 | `mlip_platform.core.optimize` | `run_optimization(atoms, ...)` | Geometry optimization with progress logging and plots |
 | `mlip_platform.core.optimize` | `OPTIMIZER_MAP` | dict of supported ASE optimizers |
@@ -42,6 +43,17 @@ setup_calculator(atoms, mlip="uma-s-1p2", uma_task="omat")  # mutates atoms.calc
 
 `device` selects the compute device (`"auto"` → cuda if available else cpu, or force `"cuda"` / `"cpu"`). `mace_head` is ignored for non-MH models; `uma_task` is ignored for non-UMA models.
 
+To relax or evaluate **many** structures, load the model once with `build_calculator` and reuse the returned calculator, instead of calling `setup_calculator` (which rebuilds it) per structure. This is what `optimize batch` does internally:
+
+```python
+from mlip_platform.cli.utils import build_calculator
+
+calc = build_calculator(mlip="uma-s-1p2", uma_task="omat")  # expensive: loads weights once
+for atoms in many_structures:
+    atoms.calc = calc                                        # cheap: reuse across all
+    ...
+```
+
 Auto-detection is also exposed:
 
 ```python
@@ -72,6 +84,7 @@ converged = run_optimization(
     relax_cell=False,   # True → also relax the cell (VASP ISIF=3-equivalent)
     output_dir="./relaxed",
     model_name="uma-s-1p2",
+    plot=True,          # False → skip the *_convergence.png (CSV still written)
 )
 ```
 

--- a/src/mlip_platform/cli/commands/md.py
+++ b/src/mlip_platform/cli/commands/md.py
@@ -6,6 +6,7 @@ from mlip_platform.cli.utils import (
     DEVICE_HELP,
     MACE_HEAD_HELP,
     MLIP_HELP,
+    PLOT_HELP,
     UMA_TASK_HELP,
     detect_mlip,
     setup_calculator,
@@ -78,6 +79,7 @@ def run(
             "shrink disk."
         ),
     ),
+    plot: bool = typer.Option(False, "--plot/--no-plot", help=PLOT_HELP),
 ):
     """
     Run molecular dynamics simulation using a supported MLIP model.
@@ -215,14 +217,17 @@ def run(
         model_name=mlip,
         resume=resume,
         csv_flush_every=csv_flush_every,
+        plot=plot,
     )
 
     # List output files
     typer.echo("\n✅ MD complete. Output written to:")
-    output_files = ["md.traj", "md_energy.csv", "md_energy.png", "md_temperature.png"]
+    output_files = ["md.traj", "md_energy.csv"]
 
-    if ensemble == 'npt':
-        output_files.extend(["md_pressure.png", "md_volume.png"])
+    if plot:
+        output_files.extend(["md_energy.png", "md_temperature.png"])
+        if ensemble == 'npt':
+            output_files.extend(["md_pressure.png", "md_volume.png"])
 
     output_files.append("md_params.txt")
 

--- a/src/mlip_platform/cli/commands/neb.py
+++ b/src/mlip_platform/cli/commands/neb.py
@@ -10,7 +10,7 @@ from ase.optimize import FIRE, MDMin, BFGS, LBFGS
 
 from mlip_platform.core.neb import CustomNEB
 from mlip_platform.core.params_io import write_parameters_file, write_endpoint_results
-from mlip_platform.cli.utils import MACE_HEAD_HELP, MLIP_HELP, UMA_TASK_HELP, parse_relax_atoms, resolve_mlip
+from mlip_platform.cli.utils import MACE_HEAD_HELP, MLIP_HELP, PLOT_HELP, UMA_TASK_HELP, parse_relax_atoms, resolve_mlip
 
 logger = logging.getLogger(__name__)
 
@@ -341,6 +341,7 @@ def run(
     endpoint_optimizer: str = typer.Option(None, help="Optimizer for endpoints: 'bfgs', 'lbfgs', 'fire'"),
     endpoint_max_steps: int = typer.Option(None, help="Maximum steps for endpoint optimization"),
     device: str = typer.Option(None, help="Compute device for the MLIP calculator: 'cpu' (default) or 'cuda'"),
+    plot: bool = typer.Option(False, "--plot/--no-plot", help=PLOT_HELP),
 ):
     """Run Nudged Elastic Band (NEB) calculation."""
     output_dir = Path.cwd()
@@ -386,11 +387,12 @@ def run(
 
     typer.echo(f"Running NEB optimization (optimizer={neb_optimizer_name.upper()}, "
                f"climb={climb_val}, max_steps={max_steps})...")
-    neb_obj.run_neb(optimizer=neb_opt, climb=climb_val, max_steps=max_steps)
+    neb_obj.run_neb(optimizer=neb_opt, climb=climb_val, max_steps=max_steps, plot=plot)
 
     typer.echo("Processing results...")
     df = neb_obj.process_results()
-    neb_obj.plot_results(df)
+    if plot:
+        neb_obj.plot_results(df)
 
     typer.echo("Exporting POSCARs...")
     neb_obj.export_poscars()
@@ -398,9 +400,12 @@ def run(
     total = params["total_images"]
     log_name = params.get("log", "neb.log")
     typer.echo("NEB complete. Output written to:")
-    for f in [log_name, "neb_convergence.csv", "neb_convergence.png",
-              "A2B.traj", "A2B_full.traj", "idpp.traj", "idpp.log",
-              "neb_data.csv", "neb_energy.png", "neb_parameters.txt"]:
+    output_files = [log_name, "neb_convergence.csv",
+                    "A2B.traj", "A2B_full.traj", "idpp.traj", "idpp.log",
+                    "neb_data.csv", "neb_parameters.txt"]
+    if plot:
+        output_files += ["neb_convergence.png", "neb_energy.png"]
+    for f in output_files:
         typer.echo(f" - {output_dir / f}")
     for i in range(total):
         typer.echo(f" - {output_dir / f'{i:02d}' / 'POSCAR'}")

--- a/src/mlip_platform/cli/commands/optimize.py
+++ b/src/mlip_platform/cli/commands/optimize.py
@@ -9,6 +9,7 @@ from mlip_platform.cli.utils import (
     DEVICE_HELP,
     MACE_HEAD_HELP,
     MLIP_HELP,
+    PLOT_HELP,
     UMA_TASK_HELP,
     build_calculator,
     detect_mlip,
@@ -61,9 +62,7 @@ def run(
     trajectory: str = typer.Option("opt.traj", help="Trajectory filename"),
     logfile: str = typer.Option("opt.log", help="Log filename"),
     verbose: bool = typer.Option(True, help="Show optimization progress table (forces, energies)"),
-    no_plot: bool = typer.Option(False, "--no-plot",
-        help="Skip the per-structure convergence PNG (the CSV is still written). "
-             "Speeds up large batches of short relaxations."),
+    plot: bool = typer.Option(False, "--plot/--no-plot", help=PLOT_HELP),
 ):
     """
     Run geometry optimization using a supported MLIP model.
@@ -118,7 +117,7 @@ def run(
         model_name=mlip,
         verbose=verbose,
         relax_cell=relax_cell,
-        plot=not no_plot,
+        plot=plot,
     )
 
     # Save parameters
@@ -149,10 +148,12 @@ def run(
         trajectory,
         logfile,
         f"{logfile_stem}_convergence.csv",
-        f"{logfile_stem}_convergence.png",
         f"{logfile_stem}_final.vasp",
+        "CONTCAR",
         "opt_params.txt"
     ]
+    if plot:
+        output_files.insert(3, f"{logfile_stem}_convergence.png")
     for file in output_files:
         typer.echo(f"   📄 {(output_dir / file).resolve()}")
 
@@ -188,9 +189,7 @@ def batch(
         False, "--skip-existing",
         help="Skip subdirectories that already contain a CONTCAR (resume a partial batch)."),
     verbose: bool = typer.Option(False, help="Show per-structure optimization progress table"),
-    no_plot: bool = typer.Option(False, "--no-plot",
-        help="Skip the per-structure convergence PNG (the CSV is still written). "
-             "Speeds up large batches of short relaxations."),
+    plot: bool = typer.Option(False, "--plot/--no-plot", help=PLOT_HELP),
 ):
     """
     Relax a series of structures, loading the MLIP model only once.
@@ -270,7 +269,7 @@ def batch(
                 model_name=mlip,
                 verbose=verbose,
                 relax_cell=relax_cell,
-                plot=not no_plot,
+                plot=plot,
             )
             walltime = time.perf_counter() - t0
             energy = atoms.get_potential_energy()

--- a/src/mlip_platform/cli/utils.py
+++ b/src/mlip_platform/cli/utils.py
@@ -37,6 +37,12 @@ DEVICE_HELP = (
     "CUDA_VISIBLE_DEVICES to pick which GPU."
 )
 
+PLOT_HELP = (
+    "Write PNG plots of the results. Off by default (plotting is opt-in): the "
+    "figure/save is IO that dominates short runs, so pass --plot only when you "
+    "want the figures. The CSV data is always written and can be plotted later."
+)
+
 
 # ---------------------------------------------------------------------------
 # Package availability checks (lightweight, no heavy imports)
@@ -167,7 +173,13 @@ def _no_mlip_message() -> str:
 
 
 def detect_mlip() -> str:
-    """Detect available MLIP model in order of preference: UMA > SevenNet > MACE > CHGNet.
+    """Detect available MLIP model in order of preference: UMA > MACE > SevenNet > CHGNet.
+
+    UMA is preferred when installed (the most accurate foundation model
+    available here), but it is gated on Hugging Face and unusable without first
+    requesting access. MACE is therefore placed ahead of SevenNet/CHGNet as the
+    readily-usable fallback: a fresh environment with ``pip install mace-torch``
+    lands on a working model without any access request.
 
     Returns
     -------
@@ -181,10 +193,10 @@ def detect_mlip() -> str:
     """
     if FAIRCHEM_AVAILABLE:
         return "uma-s-1p2"
-    elif SEVENN_AVAILABLE:
-        return "7net-mf-ompa"
     elif MACE_AVAILABLE:
         return "mace"
+    elif SEVENN_AVAILABLE:
+        return "7net-mf-ompa"
     elif CHGNET_AVAILABLE:
         return "chgnet"
     else:

--- a/src/mlip_platform/core/md.py
+++ b/src/mlip_platform/core/md.py
@@ -182,6 +182,7 @@ def run_md(
     model_name: str = "mlip",
     resume: bool = False,
     csv_flush_every: int = 100,
+    plot: bool = False,
 ) -> None:
     """Run molecular dynamics simulation.
 
@@ -207,6 +208,10 @@ def run_md(
     csv_flush_every : int
         Append buffered rows to md_energy.csv every N log_properties calls so
         the file grows incrementally instead of appearing only at end of run.
+    plot : bool
+        If True, write the md_energy/md_temperature (and NPT md_pressure/
+        md_volume) PNGs. Defaults to False -- plotting is opt-in; md_energy.csv
+        is always written and can be plotted later.
 
     (Other parameters as in :func:`setup_dynamics`.)
     """
@@ -309,6 +314,11 @@ def run_md(
     _flush_csv()  # final tail of buffered rows
 
     df = pd.DataFrame(log_data)
+
+    # Plotting is opt-in. md_energy.csv is already written above, so returning
+    # here just skips the PNGs (which are IO that can dominate short runs).
+    if not plot:
+        return
 
     # Plot energy: potential/total on the left axis, kinetic on a twin
     # right axis -- kinetic is orders of magnitude smaller than |E_pot|,

--- a/src/mlip_platform/core/neb.py
+++ b/src/mlip_platform/core/neb.py
@@ -578,6 +578,7 @@ class CustomNEB:
         full_traj: str = "A2B_full.traj",
         climb: bool = False,
         max_steps: int = 600,
+        plot: bool = False,
     ) -> list:
         """Run NEB optimization.
 
@@ -593,6 +594,9 @@ class CustomNEB:
             Enable climbing image NEB.
         max_steps : int
             Maximum number of optimization steps.
+        plot : bool
+            If True, write neb_convergence.png. Defaults to False -- plotting is
+            opt-in; neb_convergence.csv is always written.
 
         Returns
         -------
@@ -641,7 +645,8 @@ class CustomNEB:
         csv_path = self.output_dir / "neb_convergence.csv"
         df_conv = pd.DataFrame(log_data)
         df_conv.to_csv(csv_path, index=False)
-        self._plot_convergence(df_conv)
+        if plot:
+            self._plot_convergence(df_conv)
 
         # Ensure final energies are computed
         for image in self.images:

--- a/src/mlip_platform/core/optimize.py
+++ b/src/mlip_platform/core/optimize.py
@@ -48,7 +48,7 @@ def run_optimization(
     model_name: str = "mlip",
     verbose: bool = True,
     relax_cell: bool = False,
-    plot: bool = True,
+    plot: bool = False,
 ) -> bool:
     """Run geometry optimization on an ASE Atoms object.
 
@@ -80,11 +80,11 @@ def run_optimization(
         ISIF=3). Uses ``ase.filters.FrechetCellFilter`` when available,
         otherwise ``ase.constraints.ExpCellFilter``.
     plot : bool
-        If True (default), write the ``*_convergence.png`` figure. Set False to
-        skip it -- the matplotlib figure/save is per-structure IO that dominates
-        short relaxations (e.g. frozen-surface site scans), so disabling it
-        materially speeds up large batches. The ``*_convergence.csv`` is always
-        written, so the data is retained either way.
+        If True, write the ``*_convergence.png`` figure. Defaults to False:
+        the matplotlib figure/save is per-structure IO that dominates short
+        relaxations (e.g. frozen-surface site scans), so plotting is opt-in.
+        The ``*_convergence.csv`` is always written, so the data is retained
+        either way and can be plotted later.
 
     Returns
     -------

--- a/tests/test_cli_run_plot.py
+++ b/tests/test_cli_run_plot.py
@@ -1,0 +1,147 @@
+"""CLI-level tests for the `run` subcommands, focused on opt-in plotting.
+
+These drive `optimize run`, `md run`, and `neb run` through Typer's CliRunner
+with the MLIP calculator mocked to EMT, so the full command body (including the
+output-file listing) executes without a real model. The behavioural contract:
+plotting is opt-in -- PNGs appear only with `--plot`; the CSV data always does.
+"""
+import numpy as np
+from ase.build import bulk
+from ase.calculators.emt import EMT
+from ase.io import write
+from typer.testing import CliRunner
+
+from mlip_platform.cli.commands import optimize as opt_cmd
+from mlip_platform.cli.commands import md as md_cmd
+from mlip_platform.cli.commands import neb as neb_cmd
+from mlip_platform.core.neb import CustomNEB
+
+runner = CliRunner()
+
+
+def _attach_emt(atoms, *args, **kwargs):
+    atoms.calc = EMT()
+    return atoms
+
+
+def _write_structure(path, atoms):
+    write(str(path), atoms, format="vasp")
+
+
+class TestOptimizeRunPlot:
+    def _patch(self, monkeypatch):
+        monkeypatch.setattr(opt_cmd, "validate_mlip", lambda *a, **k: None)
+        monkeypatch.setattr(opt_cmd, "setup_calculator", _attach_emt)
+
+    def test_no_png_by_default(self, tmp_path, monkeypatch):
+        self._patch(monkeypatch)
+        s = tmp_path / "POSCAR"
+        _write_structure(s, bulk("Cu", "fcc", a=3.7))
+        r = runner.invoke(opt_cmd.app, [
+            "run", "--structure", str(s), "--mlip", "mace",
+            "--fmax", "0.1", "--max-steps", "30",
+        ])
+        assert r.exit_code == 0, r.output
+        assert (tmp_path / "opt_convergence.csv").exists()
+        assert not (tmp_path / "opt_convergence.png").exists()
+
+    def test_png_with_plot(self, tmp_path, monkeypatch):
+        self._patch(monkeypatch)
+        s = tmp_path / "POSCAR"
+        _write_structure(s, bulk("Cu", "fcc", a=3.7))
+        r = runner.invoke(opt_cmd.app, [
+            "run", "--structure", str(s), "--mlip", "mace",
+            "--fmax", "0.1", "--max-steps", "30", "--plot",
+        ])
+        assert r.exit_code == 0, r.output
+        assert (tmp_path / "opt_convergence.png").exists()
+
+
+class TestMdRunPlot:
+    def _patch(self, monkeypatch):
+        monkeypatch.setattr(md_cmd, "validate_mlip", lambda *a, **k: None)
+        monkeypatch.setattr(md_cmd, "setup_calculator", _attach_emt)
+
+    def test_no_png_by_default(self, tmp_path, monkeypatch):
+        self._patch(monkeypatch)
+        s = tmp_path / "POSCAR"
+        _write_structure(s, bulk("Cu", "fcc", a=3.6) * (2, 2, 2))
+        r = runner.invoke(md_cmd.app, [
+            "--structure", str(s), "--mlip", "mace",
+            "--ensemble", "nve", "--steps", "3",
+            "--log-interval", "1", "--traj-interval", "1",
+        ])
+        assert r.exit_code == 0, r.output
+        assert (tmp_path / "md_energy.csv").exists()
+        assert not (tmp_path / "md_energy.png").exists()
+
+    def test_png_with_plot(self, tmp_path, monkeypatch):
+        self._patch(monkeypatch)
+        s = tmp_path / "POSCAR"
+        _write_structure(s, bulk("Cu", "fcc", a=3.6) * (2, 2, 2))
+        r = runner.invoke(md_cmd.app, [
+            "--structure", str(s), "--mlip", "mace",
+            "--ensemble", "nve", "--steps", "3",
+            "--log-interval", "1", "--traj-interval", "1", "--plot",
+        ])
+        assert r.exit_code == 0, r.output
+        assert (tmp_path / "md_energy.png").exists()
+        assert (tmp_path / "md_temperature.png").exists()
+
+    def test_npt_png_with_plot(self, tmp_path, monkeypatch):
+        self._patch(monkeypatch)
+        s = tmp_path / "POSCAR"
+        _write_structure(s, bulk("Cu", "fcc", a=3.6) * (2, 2, 2))
+        r = runner.invoke(md_cmd.app, [
+            "--structure", str(s), "--mlip", "mace",
+            "--ensemble", "npt", "--temperature", "300", "--pressure", "0.0",
+            "--barostat", "berendsen", "--steps", "3",
+            "--log-interval", "1", "--traj-interval", "1", "--plot",
+        ])
+        assert r.exit_code == 0, r.output
+        assert (tmp_path / "md_pressure.png").exists()
+        assert (tmp_path / "md_volume.png").exists()
+
+
+class TestNebRunPlot:
+    def _patch(self, monkeypatch):
+        # NEB builds a calculator per image via CustomNEB.setup_calculator(),
+        # and resolves the MLIP name up front; mock both so no model is needed.
+        monkeypatch.setattr(CustomNEB, "setup_calculator", lambda self, *a, **k: EMT())
+        monkeypatch.setattr(neb_cmd, "resolve_mlip", lambda m=None: "mace")
+
+    def _pair(self, tmp_path):
+        initial = bulk("Cu", "fcc", a=3.6) * (2, 2, 2)
+        final = initial.copy()
+        pos = final.get_positions()
+        pos[0] += np.array([0.3, 0.3, 0.0])
+        final.set_positions(pos)
+        _write_structure(tmp_path / "initial.vasp", initial)
+        _write_structure(tmp_path / "final.vasp", final)
+        return tmp_path / "initial.vasp", tmp_path / "final.vasp"
+
+    def _args(self, ini, fin, extra):
+        return [
+            "--initial", str(ini), "--final", str(fin),
+            "--mlip", "mace", "--num-images", "3", "--fmax", "0.5",
+            "--neb-max-steps", "2", "--no-optimize-endpoints",
+        ] + extra
+
+    def test_no_png_by_default(self, tmp_path, monkeypatch):
+        self._patch(monkeypatch)
+        monkeypatch.chdir(tmp_path)  # neb writes to CWD
+        ini, fin = self._pair(tmp_path)
+        r = runner.invoke(neb_cmd.app, self._args(ini, fin, []))
+        assert r.exit_code == 0, r.output
+        assert (tmp_path / "neb_convergence.csv").exists()
+        assert not (tmp_path / "neb_convergence.png").exists()
+        assert not (tmp_path / "neb_energy.png").exists()
+
+    def test_png_with_plot(self, tmp_path, monkeypatch):
+        self._patch(monkeypatch)
+        monkeypatch.chdir(tmp_path)
+        ini, fin = self._pair(tmp_path)
+        r = runner.invoke(neb_cmd.app, self._args(ini, fin, ["--plot"]))
+        assert r.exit_code == 0, r.output
+        assert (tmp_path / "neb_convergence.png").exists()
+        assert (tmp_path / "neb_energy.png").exists()

--- a/tests/test_cli_utils.py
+++ b/tests/test_cli_utils.py
@@ -30,15 +30,23 @@ class TestDetectMlip:
         assert detect_mlip() == "uma-s-1p2"
 
     @patch("mlip_platform.cli.utils.FAIRCHEM_AVAILABLE", False)
+    @patch("mlip_platform.cli.utils.MACE_AVAILABLE", True)
+    def test_falls_back_to_mace(self):
+        # Without UMA, MACE is the preferred fallback (it is not gated).
+        assert detect_mlip() == "mace"
+
+    @patch("mlip_platform.cli.utils.FAIRCHEM_AVAILABLE", False)
+    @patch("mlip_platform.cli.utils.MACE_AVAILABLE", True)
+    @patch("mlip_platform.cli.utils.SEVENN_AVAILABLE", True)
+    def test_mace_preferred_over_sevenn(self):
+        # When both MACE and SevenNet are installed, MACE wins (readily usable).
+        assert detect_mlip() == "mace"
+
+    @patch("mlip_platform.cli.utils.FAIRCHEM_AVAILABLE", False)
+    @patch("mlip_platform.cli.utils.MACE_AVAILABLE", False)
     @patch("mlip_platform.cli.utils.SEVENN_AVAILABLE", True)
     def test_falls_back_to_sevenn(self):
         assert detect_mlip() == "7net-mf-ompa"
-
-    @patch("mlip_platform.cli.utils.FAIRCHEM_AVAILABLE", False)
-    @patch("mlip_platform.cli.utils.SEVENN_AVAILABLE", False)
-    @patch("mlip_platform.cli.utils.MACE_AVAILABLE", True)
-    def test_falls_back_to_mace(self):
-        assert detect_mlip() == "mace"
 
     @patch("mlip_platform.cli.utils.FAIRCHEM_AVAILABLE", False)
     @patch("mlip_platform.cli.utils.SEVENN_AVAILABLE", False)

--- a/tests/test_core_md.py
+++ b/tests/test_core_md.py
@@ -59,6 +59,19 @@ class TestRunMd:
 
         assert (tmp_workdir / "md.traj").exists()
         assert (tmp_workdir / "md_energy.csv").exists()
+        # Plotting is opt-in: no PNGs unless plot=True.
+        assert not (tmp_workdir / "md_energy.png").exists()
+        assert not (tmp_workdir / "md_temperature.png").exists()
+
+    def test_short_nve_plot_opt_in(self, tmp_workdir):
+        atoms = bulk("Cu", "fcc", a=3.6) * (2, 2, 2)
+        atoms.calc = EMT()
+
+        run_md(
+            atoms, ensemble="nve", steps=5, log_interval=1, traj_interval=1,
+            output_dir=tmp_workdir, plot=True,
+        )
+
         assert (tmp_workdir / "md_energy.png").exists()
         assert (tmp_workdir / "md_temperature.png").exists()
 

--- a/tests/test_core_neb.py
+++ b/tests/test_core_neb.py
@@ -112,3 +112,29 @@ class TestExportPoscars:
         for i in range(5):
             poscar = tmp_workdir / f"{i:02d}" / "POSCAR"
             assert poscar.exists(), f"POSCAR missing for image {i}"
+
+
+class TestRunNebPlotting:
+    """run_neb always writes neb_convergence.csv; the PNG is opt-in (plot=True)."""
+
+    def _emt_neb(self, tmp_workdir, monkeypatch):
+        initial, final = _make_neb_pair()
+        neb = CustomNEB(
+            initial=initial, final=final, num_images=3,
+            mlip="test", output_dir=tmp_workdir,
+        )
+        # run_neb builds a calculator per image via self.setup_calculator();
+        # swap in EMT so the run works without a real MLIP installed.
+        monkeypatch.setattr(neb, "setup_calculator", lambda: EMT())
+        return neb
+
+    def test_no_png_by_default(self, tmp_workdir, monkeypatch):
+        neb = self._emt_neb(tmp_workdir, monkeypatch)
+        neb.run_neb(max_steps=2)
+        assert (tmp_workdir / "neb_convergence.csv").exists()
+        assert not (tmp_workdir / "neb_convergence.png").exists()
+
+    def test_png_when_plot_true(self, tmp_workdir, monkeypatch):
+        neb = self._emt_neb(tmp_workdir, monkeypatch)
+        neb.run_neb(max_steps=2, plot=True)
+        assert (tmp_workdir / "neb_convergence.png").exists()

--- a/tests/test_core_optimize.py
+++ b/tests/test_core_optimize.py
@@ -29,9 +29,19 @@ class TestOptimizationConverges:
         assert (tmp_workdir / "opt.traj").exists()
         assert (tmp_workdir / "opt.log").exists()
         assert (tmp_workdir / "opt_convergence.csv").exists()
-        assert (tmp_workdir / "opt_convergence.png").exists()
         assert (tmp_workdir / "opt_final.vasp").exists()
         assert (tmp_workdir / "CONTCAR").exists()
+        # Plotting is opt-in: no PNG unless plot=True.
+        assert not (tmp_workdir / "opt_convergence.png").exists()
+
+    def test_plot_opt_in_writes_png(self, tmp_workdir):
+        atoms = bulk("Cu", "fcc", a=3.7)
+        atoms.calc = EMT()
+        run_optimization(
+            atoms, optimizer="bfgs", fmax=0.1, max_steps=50,
+            output_dir=tmp_workdir, verbose=False, plot=True,
+        )
+        assert (tmp_workdir / "opt_convergence.png").exists()
 
     def test_convergence_csv_has_data(self, tmp_workdir):
         import pandas as pd


### PR DESCRIPTION
This branch bundles the post-0.3.0 documentation sync with two user-requested behavior changes. Three commits, reviewable independently.

## 1. Docs sync (commit 1)

Brought README / CHANGELOG / CONTRIBUTING / PYTHON_API / OUTPUTS in line with post-0.3.0 features that the June doc-sync (#20) missed: NEB `--device`, NEB multi-head MACE support, `improvedtangent` method, MLIP head/task logging, the CI diff-coverage gate, `optimize --no-plot`, and `build_calculator`. Fixed stale `uma-s-1p1`/`uma-m-1p1` references.

## 2. MACE-preferred auto-detect fallback (commit 2)

`--mlip auto` order changed **UMA -> SevenNet -> MACE -> CHGNet** to **UMA -> MACE -> SevenNet -> CHGNet**.

UMA stays preferred when installed, but MACE moves ahead of SevenNet/CHGNet as the readily-usable fallback: UMA is gated on Hugging Face and unusable without an access request, whereas `pip install mace-torch` gives a working model immediately. A fresh environment now lands on a usable default.

## 3. Opt-in plotting across optimize / md / neb (commit 2)

PNG plotting is now **opt-in**. Previously `optimize` had a `--no-plot` opt-out and `md`/`neb` always plotted with no way to disable. Now:

- No PNG is written unless `--plot` is passed (new `--plot/--no-plot` flag on `optimize run`, `optimize batch`, `md run`, `neb run`).
- The CSV data is **always** written (`*_convergence.csv`, `md_energy.csv`, `neb_convergence.csv`, `neb_data.csv`), so nothing is lost.
- Motivation: the figure/save is IO that dominates short runs (~3x speedup measured on frozen-surface site scans).
- `--no-plot` still works (off side of `--plot/--no-plot`), so existing scripts are unaffected.

Threaded through `run_optimization(plot=)`, `run_md(plot=)`, `CustomNEB.run_neb(plot=)`.

## Tests (commits 2 & 3)

- Detection-order tiebreak (MACE preferred over SevenNet).
- Plot opt-in for `run_optimization`, `run_md`, and a new EMT-backed `run_neb` test.
- CLI-level `run` tests (optimize/md/neb) driving the full command body with a mocked EMT calculator.

**Verification:** `pytest -m "not uma and not mace and not sevenn"` -> 128 passed, 6 skipped. Local `diff-cover` against origin/main -> **100% on changed lines** (gate requires >=90%).

Generated with Claude Code
