### PR TITLE
fix(install): pull real asetools from GitHub via direct reference

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -22,8 +22,8 @@ jobs:
       - name: Install package with dev deps
         run: |
           python -m pip install --upgrade pip
-          # PyPI's "asetools" is an unrelated package; install the real one from GitHub.
-          pip install git+https://github.com/manuelarcer/asetools.git
+          # asetools comes from GitHub via setup.py's direct reference; no
+          # separate install step, so CI exercises the same path users run.
           pip install -e ".[dev]"
 
       - name: Run test suite with coverage

--- a/.github/workflows/weekly.yml
+++ b/.github/workflows/weekly.yml
@@ -22,8 +22,8 @@ jobs:
       - name: Install package with dev deps
         run: |
           python -m pip install --upgrade pip
-          # PyPI's "asetools" is an unrelated package; install the real one from GitHub.
-          pip install git+https://github.com/manuelarcer/asetools.git
+          # asetools comes from GitHub via setup.py's direct reference; no
+          # separate install step, so CI exercises the same path users run.
           pip install -e ".[dev]"
 
       - name: Dependency vulnerability audit (report only, no upgrades)

--- a/README.md
+++ b/README.md
@@ -40,10 +40,14 @@ git clone https://github.com/manuelarcer/mlip-platform.git
 cd mlip-platform
 ```
 
-2. **Install the package** (also installs [asetools](https://github.com/manuelarcer/asetools) dependency)
+2. **Install the package**
 ```bash
 pip install -e .
 ```
+
+This also installs the [asetools](https://github.com/manuelarcer/asetools) dependency directly from GitHub.
+
+> **Warning**: Do not `pip install asetools` manually — the package named `asetools` on PyPI is an unrelated project (Aseprite tooling). `pip install -e .` pulls the correct one from GitHub automatically. If the wrong one is already installed, remove it first: `pip uninstall asetools`, then rerun `pip install -e .`.
 
 3. **Install MLIP models** (choose one or more)
 

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,9 @@ setup(
         "pandas",
         "matplotlib",
         "scipy",
-        "asetools",
+        # PyPI's "asetools" is an unrelated package (Aseprite tooling); the
+        # real dependency lives on GitHub, so pin it as a direct reference.
+        "asetools @ git+https://github.com/manuelarcer/asetools.git",
     ],
     extras_require={
         "dev": [


### PR DESCRIPTION
## Problem

`setup.py` declared a plain `asetools` dependency, but PyPI's `asetools` is an unrelated package ("Tools to work with Aseprite files"). A fresh `pip install -e .` therefore silently installed the wrong package. The only consumer (`src/mlip_platform/core/neb.py`, interpolation sanity check) guards its import with `try/except ImportError`, so the check silently never ran — a working-looking install with a feature quietly missing. CI already worked around this with a separate `pip install git+...` step, so the user-facing path was never exercised.

## Fix

- **setup.py**: declare the dependency as a PEP 508 direct reference — `asetools @ git+https://github.com/manuelarcer/asetools.git` — so `pip install -e .` pulls the real package.
- **README**: correct the Quick Start claim; warn against `pip install asetools` from PyPI, with the recovery command if the impostor is already installed.
- **CI (tests.yml, weekly.yml)**: drop the separate asetools install step so both workflows now install exactly what a user installs.

## Verification

Fresh venv, `pip install -e .` from this branch:
- pip builds `asetools 0.2.0` from GitHub (PyPI impostor is 0.1.1)
- `from asetools.pathways.neb import check_atomic_distances` imports — the NEB sanity check is live again
- `mlip --help` entry point works
- `pytest -m "not uma and not mace and not sevenn"`: **128 passed, 6 skipped, 5 deselected**

No golden files touched. One concern per PR — the onboarding docs (`AGENTS.md`), `mlip doctor`, and fresh-install smoke CI follow in a stacked PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)