### PR TITLE
feat(onboarding): mlip doctor, agent guide, fresh-install smoke CI

### DIFF
--- a/.github/workflows/install-smoke.yml
+++ b/.github/workflows/install-smoke.yml
@@ -1,0 +1,67 @@
+name: Fresh-install smoke test
+
+# Proves the README Quick Start works on a clean machine: base install,
+# [neb] extra, MACE, `mlip doctor`, and a tiny CPU relaxation end-to-end.
+# Runs weekly, on demand, and whenever packaging files change.
+on:
+  schedule:
+    - cron: "0 21 * * 0"  # Mondays 05:00 SGT (UTC+8), before the weekly checks
+  workflow_dispatch: {}
+  pull_request:
+    paths:
+      - pyproject.toml
+      - setup.py
+      - .github/workflows/install-smoke.yml
+
+jobs:
+  fresh-install:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    env:
+      MPLBACKEND: Agg
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Base install (exact README Quick Start path)
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e .
+          mlip --help
+
+      - name: "[neb] extra pulls the real asetools (not the PyPI impostor)"
+        run: |
+          pip install -e ".[neb]"
+          python -c "from asetools.pathways.neb import check_atomic_distances; print('real asetools OK')"
+
+      - name: Install MACE (CPU torch to keep the runner light)
+        run: |
+          pip install torch --index-url https://download.pytorch.org/whl/cpu
+          pip install mace-torch
+
+      - name: mlip doctor gates the environment
+        run: |
+          mlip doctor
+          mlip doctor | grep -q "mace-torch"
+
+      - name: Tiny MACE relaxation end-to-end (CPU)
+        run: |
+          mkdir smoke && cd smoke
+          python -c "
+          from ase.build import bulk
+          from ase.io import write
+          write('POSCAR', bulk('Cu', 'fcc', a=3.6, cubic=True), format='vasp')
+          "
+          optimize run --structure POSCAR --mlip mace --device cpu --fmax 0.5 --max-steps 3
+          python -c "
+          import csv, math
+          rows = list(csv.DictReader(open('opt_convergence.csv')))
+          assert rows, 'no convergence data written'
+          energy = float(rows[-1]['energy(eV)'])
+          assert math.isfinite(energy), f'non-finite energy: {energy}'
+          print(f'{len(rows)} steps, final energy {energy:.3f} eV')
+          "
+          test -f CONTCAR

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -22,9 +22,8 @@ jobs:
       - name: Install package with dev deps
         run: |
           python -m pip install --upgrade pip
-          # PyPI's "asetools" is an unrelated package; install the real one from GitHub.
-          pip install git+https://github.com/manuelarcer/asetools.git
-          pip install -e ".[dev]"
+          # [neb] pulls the real asetools from GitHub (PyPI's "asetools" is unrelated).
+          pip install -e ".[dev,neb]"
 
       - name: Run test suite with coverage
         run: pytest --cov=mlip_platform --cov-report=xml

--- a/.github/workflows/weekly.yml
+++ b/.github/workflows/weekly.yml
@@ -22,9 +22,8 @@ jobs:
       - name: Install package with dev deps
         run: |
           python -m pip install --upgrade pip
-          # PyPI's "asetools" is an unrelated package; install the real one from GitHub.
-          pip install git+https://github.com/manuelarcer/asetools.git
-          pip install -e ".[dev]"
+          # [neb] pulls the real asetools from GitHub (PyPI's "asetools" is unrelated).
+          pip install -e ".[dev,neb]"
 
       - name: Dependency vulnerability audit (report only, no upgrades)
         run: |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,83 @@
+# Agent guide — mlip-platform
+
+Orientation for AI coding assistants (Claude Code, Cursor, Codex, …) and new
+users driving this repo. Everything here is also human-readable; the README
+covers usage in more depth.
+
+## What this is
+
+A CLI + Python API that drives ASE-based **geometry optimization, molecular
+dynamics, and NEB/AutoNEB transition-state searches** using machine-learning
+interatomic potentials (MLIPs): UMA (fairchem-core), MACE (mace-torch),
+SevenNet (sevenn), and CHGNet (chgnet). `CONTEXT.md` defines the project
+vocabulary (MLIP tag vs package vs env) — read it before discussing installs.
+
+## Install (fresh machine)
+
+```bash
+git clone https://github.com/manuelarcer/mlip-platform.git
+cd mlip-platform
+pip install -e .          # base install: CLI + ASE, no MLIP yet
+pip install mace-torch    # simplest working MLIP (no access request needed)
+mlip doctor               # verify: exits 0 when the env is usable
+```
+
+Rules that are easy to get wrong:
+
+1. **One MLIP package per Python environment.** mace-torch, fairchem-core,
+   sevenn, and chgnet pin mutually incompatible torch/e3nn versions.
+   Installing two into one env can silently break at least one. Tested
+   per-MLIP recipes (conda and venv, CPU and CUDA): `docs/install/README.md`;
+   rationale: `docs/adr/0001-per-mlip-envs.md`.
+2. **Never `pip install asetools`.** PyPI's `asetools` is an unrelated
+   Aseprite tool that shadows the real dependency. asetools is optional here
+   (it enables the NEB interpolation sanity check); the correct way to get it
+   is the extra `pip install -e ".[neb]"`, which pulls it from GitHub. If the
+   impostor is installed: `pip uninstall asetools`, then reinstall the extra.
+3. **UMA is gated.** fairchem-core needs a Hugging Face access request before
+   any UMA model runs — see `docs/UMA_USAGE_GUIDE.md`. MACE works immediately,
+   which is why `--mlip auto` falls back to it (order: UMA → MACE → SevenNet
+   → CHGNet).
+4. **Model weights download on first use** into `~/.cache/mace/` (and the
+   Hugging Face cache for UMA). Air-gapped compute nodes need the checkpoint
+   pre-fetched — commands are in the install recipes.
+
+`mlip doctor` reports all of the above states (versions, asetools health,
+installed MLIPs, `--mlip auto` resolution, torch/CUDA) and exits 1 if no
+MLIP is installed — script against its exit code.
+
+## Running
+
+- Entry points: `mlip <subcmd>` or standalone `optimize`, `md`, `neb`,
+  `autoneb`, `autoneb-results`, `benchmark`. All support `--help`.
+- Typical: `optimize run --structure POSCAR --fmax 0.05`. Model selection via
+  `--mlip` (default `auto`), device via `--device` (note: `neb` defaults to
+  CPU, the others to auto).
+- Plots are **opt-in** (`--plot`); CSV outputs are always written.
+- Output locations differ: `optimize`/`md` write next to the input structure;
+  `neb`/`autoneb` write into the current working directory. Full file
+  reference: `docs/OUTPUTS.md`.
+- Python API (for scripts/notebooks): `docs/PYTHON_API.md`.
+
+## Testing
+
+```bash
+pip install -e ".[dev,neb]"
+pytest -m "not uma and not mace and not sevenn"   # unit tests, no MLIP needed
+pytest                                             # + integration (needs MLIPs)
+```
+
+- CI gates: full unit suite + diff coverage ≥ 90% on changed lines
+  (`.github/workflows/tests.yml`).
+- **Never regenerate golden reference files** (`tests/goldens/*.json`). If a
+  golden test fails, report the numerical delta; updating baselines is a
+  human decision. `scripts/generate_goldens.py` refuses to overwrite.
+- Every test must assert a numerical value or invariant. Loosening a
+  tolerance (recording the observed delta) is acceptable; silently changed
+  numerics are not — numerical correctness is this package's top priority.
+
+## Contribution conventions
+
+- Draft PRs only; never push to main. One concern per PR.
+- Match the existing code style: typer CLI, lazy imports for heavy packages,
+  NumPy-style docstrings. See `CONTRIBUTING.md`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,6 @@
+# mlip-platform
+
+Read `AGENTS.md` for the full agent guide: install rules (one MLIP per env,
+the asetools PyPI trap, gated UMA), `mlip doctor` verification, testing
+commands, and the frozen-goldens policy. `CONTEXT.md` defines the project
+vocabulary.

--- a/README.md
+++ b/README.md
@@ -40,12 +40,19 @@ git clone https://github.com/manuelarcer/mlip-platform.git
 cd mlip-platform
 ```
 
-2. **Install the package** (also installs [asetools](https://github.com/manuelarcer/asetools) dependency)
+2. **Install the package**
 ```bash
 pip install -e .
 ```
 
-3. **Install MLIP models** (choose one or more)
+Optional: the NEB interpolation sanity check uses [asetools](https://github.com/manuelarcer/asetools). Enable it with:
+```bash
+pip install -e ".[neb]"
+```
+
+> **Warning**: Never `pip install asetools` directly — the package named `asetools` on PyPI is an unrelated project (Aseprite tooling). The `[neb]` extra pulls the correct one from GitHub. If the wrong one is already installed: `pip uninstall asetools`, then `pip install -e ".[neb]"`.
+
+3. **Install an MLIP model** (each in its own environment — see [install recipes](docs/install/README.md))
 
 ```bash
 # MACE - readily usable, no access request (good default for a fresh setup)
@@ -61,7 +68,14 @@ pip install sevenn
 pip install chgnet
 ```
 
-> **Note**: Models can coexist in the same environment. With `--mlip auto` (the default), the CLI picks the first available in the order **UMA → MACE → SevenNet → CHGNet**, or you can pass `--mlip <name>` to force a specific one. UMA is preferred when installed (it is the most accurate), but it is gated on Hugging Face and unusable without an access request — so MACE is placed ahead of SevenNet/CHGNet as the readily-usable fallback. A fresh environment with only `pip install mace-torch` lands on a working model with no access request. UMA's Hugging Face setup is covered in [UMA_USAGE_GUIDE.md](docs/UMA_USAGE_GUIDE.md#2-hugging-face-access).
+4. **Verify the install**
+```bash
+mlip doctor
+```
+
+Reports Python/package versions, asetools health, installed MLIP packages, what `--mlip auto` resolves to, and torch/CUDA status. Exits non-zero if no MLIP is installed, so it can be scripted.
+
+> **Note**: With `--mlip auto` (the default), the CLI picks the first available in the order **UMA → MACE → SevenNet → CHGNet**, or you can pass `--mlip <name>` to force a specific one. Prefer one MLIP per environment: the packages pin mutually incompatible torch/e3nn versions, so installing several into one env can silently break — see [ADR 0001](docs/adr/0001-per-mlip-envs.md). UMA is preferred when installed (it is the most accurate), but it is gated on Hugging Face and unusable without an access request — so MACE is placed ahead of SevenNet/CHGNet as the readily-usable fallback. A fresh environment with only `pip install mace-torch` lands on a working model with no access request. UMA's Hugging Face setup is covered in [UMA_USAGE_GUIDE.md](docs/UMA_USAGE_GUIDE.md#2-hugging-face-access).
 
 ### Windows Setup
 
@@ -73,7 +87,7 @@ For detailed Windows installation instructions, see: [Windows Setup Guide](docs/
 
 The package installs the following entry points:
 
-- `mlip` — top-level namespace; `mlip --help` lists every subcommand
+- `mlip` — top-level namespace; `mlip --help` lists every subcommand (including `mlip doctor`, the environment self-check)
 - `optimize`, `md`, `neb`, `autoneb`, `autoneb-results`, `benchmark` — standalone aliases
 
 `mlip <subcmd>` is equivalent to running `<subcmd>` directly. For example, `mlip md run --structure POSCAR` and `md run --structure POSCAR` do the same thing. The examples below use the standalone form for brevity. All commands support `--help`.
@@ -341,7 +355,7 @@ For a complete reference of every file each command writes — filename, format,
 ## Developer Notes
 
 - CLI powered by [`typer`](https://typer.tiangolo.com/)
-- Entry points defined in [setup.py](setup.py):
+- Entry points defined in [pyproject.toml](pyproject.toml) (`[project.scripts]`):
   ```python
   console_scripts = [
       "md = mlip_platform.cli.commands.md:app",
@@ -357,7 +371,7 @@ For a complete reference of every file each command writes — filename, format,
 - Automatic plot generation for all trajectory-based calculations
 - Shared utilities in `core/utils.py` (fmax calculation, unit conversions)
 - Parameter I/O in `core/params_io.py` (reduces duplication across commands)
-- Integrates with [asetools](https://github.com/manuelarcer/asetools) for NEB sanity checks
+- Optional integration with [asetools](https://github.com/manuelarcer/asetools) for NEB interpolation sanity checks (`pip install -e ".[neb]"`; the import in `core/neb.py` is guarded, so the platform runs without it)
 
 ---
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,79 @@
+[build-system]
+requires = ["setuptools>=61.0", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "mlip-platform"
+version = "0.3.0"
+description = "CLI platform for running MLIP-based MD, NEB, and Benchmarking"
+readme = "README.md"
+requires-python = ">=3.9"
+authors = [
+    { name = "Juan M Arce-Ramos", email = "juan.arce@ihpc.a-star.edu.sg" },
+]
+classifiers = [
+    "Development Status :: 3 - Alpha",
+    "Intended Audience :: Science/Research",
+    "Topic :: Scientific/Engineering :: Chemistry",
+    "Topic :: Scientific/Engineering :: Physics",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.9",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+]
+# Base dependencies only. The MLIP backends (mace-torch, fairchem-core, sevenn,
+# chgnet) and their torch stacks are intentionally NOT listed here: they have
+# mutually incompatible pins and must be installed one-per-env via the recipes
+# in docs/install/. See ADR 0001.
+dependencies = [
+    "typer[all]",
+    "ase",
+    "pandas",
+    "matplotlib",
+    "scipy",
+]
+
+[project.optional-dependencies]
+# NEB interpolation sanity-check helper. Installed from git because the PyPI
+# name "asetools" is taken by an unrelated project (an Aseprite image tool) --
+# do NOT add a bare "asetools" to the base dependencies. The import in
+# core/neb.py is guarded, so this extra is optional; install it to enable the
+# post-interpolation atomic-distance check:
+#   pip install -e ".[neb]"
+neb = [
+    "asetools @ git+https://github.com/manuelarcer/asetools.git",
+]
+dev = [
+    "pytest",
+    "pytest-cov",
+    "diff-cover",
+    # mutmut 3.x dropped the --paths-to-mutate CLI flag and reads config from
+    # pyproject.toml ([tool.mutmut] below); pinned <3 for the flag-based CLI.
+    "mutmut>=2.4,<3.0",
+    "pip-audit",
+]
+
+[project.scripts]
+mlip = "mlip_platform.cli.main:app"
+md = "mlip_platform.cli.commands.md:app"
+neb = "mlip_platform.cli.commands.neb:app"
+autoneb = "mlip_platform.cli.commands.autoneb:app"
+autoneb-results = "mlip_platform.cli.commands.autoneb_results:app"
+benchmark = "mlip_platform.cli.commands.benchmark:app"
+optimize = "mlip_platform.cli.commands.optimize:app"
+
+[project.urls]
+Homepage = "https://github.com/manuelarcer/mlip-platform"
+Repository = "https://github.com/manuelarcer/mlip-platform"
+
+[tool.setuptools]
+package-dir = { "" = "src" }
+include-package-data = true
+zip-safe = false
+
+[tool.setuptools.packages.find]
+where = ["src"]
+
+[tool.mutmut]
+paths_to_mutate = "src/mlip_platform/"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,9 @@ classifiers = [
 # mutually incompatible pins and must be installed one-per-env via the recipes
 # in docs/install/. See ADR 0001.
 dependencies = [
-    "typer[all]",
+    # plain "typer" — the [all] extra is empty in modern typer (>=0.12 bundles
+    # rich and shellingham) and only produces a pip warning on fresh installs
+    "typer",
     "ase",
     "pandas",
     "matplotlib",

--- a/setup.py
+++ b/setup.py
@@ -1,55 +1,6 @@
-from setuptools import setup, find_packages
+# Project metadata now lives in pyproject.toml (PEP 621).
+# This shim remains so that legacy `python setup.py` / older-pip editable
+# installs keep working; setuptools reads all fields from pyproject.toml.
+from setuptools import setup
 
-setup(
-    name="mlip-platform",
-    version="0.3.0",
-    description="CLI platform for running MLIP-based MD, NEB, and Benchmarking",
-    author="Juan M Arce-Ramos",
-    author_email="juan.arce@ihpc.a-star.edu.sg",
-    python_requires=">=3.9",
-    package_dir={"": "src"},
-    packages=find_packages(where="src"),
-    install_requires=[
-        "typer[all]",
-        "ase",
-        "pandas",
-        "matplotlib",
-        "scipy",
-        "asetools",
-    ],
-    extras_require={
-        "dev": [
-            "pytest",
-            "pytest-cov",
-            "diff-cover",
-            # mutmut 3.x dropped the --paths-to-mutate CLI flag and requires
-            # pyproject.toml config; this repo has no pyproject.toml.
-            "mutmut>=2.4,<3.0",
-            "pip-audit",
-        ],
-    },
-    classifiers=[
-        "Development Status :: 3 - Alpha",
-        "Intended Audience :: Science/Research",
-        "Topic :: Scientific/Engineering :: Chemistry",
-        "Topic :: Scientific/Engineering :: Physics",
-        "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.9",
-        "Programming Language :: Python :: 3.10",
-        "Programming Language :: Python :: 3.11",
-        "Programming Language :: Python :: 3.12",
-    ],
-    entry_points={
-        'console_scripts': [
-            'mlip = mlip_platform.cli.main:app',
-            'md = mlip_platform.cli.commands.md:app',
-            'neb = mlip_platform.cli.commands.neb:app',
-            'autoneb = mlip_platform.cli.commands.autoneb:app',
-            'autoneb-results = mlip_platform.cli.commands.autoneb_results:app',
-            'benchmark = mlip_platform.cli.commands.benchmark:app',
-            'optimize = mlip_platform.cli.commands.optimize:app',
-        ],
-    },
-    include_package_data=True,
-    zip_safe=False,
-)
+setup()

--- a/src/mlip_platform/cli/commands/doctor.py
+++ b/src/mlip_platform/cli/commands/doctor.py
@@ -1,0 +1,133 @@
+"""`mlip doctor` — environment self-check.
+
+Reports what a fresh install actually got: package versions, whether the
+optional asetools extra is present (and whether it is the real GitHub
+package or the unrelated PyPI impostor), which MLIP packages are present,
+what `--mlip auto` would resolve to, and torch/CUDA status. Exits 0 iff at
+least one MLIP package is installed; exits 1 otherwise with a fix hint, so
+scripts and CI can assert on it.
+"""
+import importlib.util
+import platform
+import sys
+from importlib.metadata import PackageNotFoundError
+from importlib.metadata import version as _dist_version
+
+import typer
+
+# (distribution, MLIP tag reported for `--mlip auto`) in detect_mlip()'s
+# preference order: UMA > MACE > SevenNet > CHGNet.
+_MLIP_PACKAGES = [
+    ("fairchem-core", "uma-s-1p2"),
+    ("mace-torch", "mace"),
+    ("sevenn", "7net-mf-ompa"),
+    ("chgnet", "chgnet"),
+]
+
+_INSTALL_DOCS = "docs/install/README.md"
+
+
+def _package_version(dist_name):
+    """Installed version of a distribution, or None if not installed."""
+    try:
+        return _dist_version(dist_name)
+    except PackageNotFoundError:
+        return None
+
+
+def _asetools_status():
+    """'ok' | 'wrong-package' | 'missing'.
+
+    PyPI's "asetools" is an unrelated project (Aseprite tooling) that
+    shadows the real dependency (github.com/manuelarcer/asetools). The two
+    are told apart by the `asetools.pathways` subpackage, which only the
+    real one has.
+    """
+    try:
+        if importlib.util.find_spec("asetools") is None:
+            return "missing"
+        if importlib.util.find_spec("asetools.pathways") is None:
+            return "wrong-package"
+    except Exception:
+        # importable-but-broken behaves like the wrong package
+        return "wrong-package"
+    return "ok"
+
+
+def _torch_info():
+    """(torch version or None, human-readable CUDA status)."""
+    torch_version = _package_version("torch")
+    if torch_version is None:
+        return None, "n/a (torch not installed)"
+    try:
+        import torch
+        if torch.cuda.is_available():
+            cuda = f"available ({torch.cuda.device_count()} device(s))"
+        else:
+            cuda = "not available (CPU only)"
+    except Exception as exc:  # a broken torch install should not crash doctor
+        cuda = f"torch import failed: {exc}"
+    return torch_version, cuda
+
+
+def doctor():
+    """Check this environment: MLIP packages, asetools health, torch/CUDA."""
+    problems = []
+
+    typer.echo("mlip-platform environment doctor")
+    typer.echo("=" * 32)
+    typer.echo(f"Python          {platform.python_version()} ({sys.platform})")
+    for dist in ("mlip-platform", "ase"):
+        typer.echo(f"{dist:<15} {_package_version(dist) or 'not installed'}")
+
+    status = _asetools_status()
+    if status == "ok":
+        typer.echo("asetools        OK (real package; NEB sanity checks active)")
+    elif status == "wrong-package":
+        typer.echo(
+            "asetools        WARN: wrong package — PyPI's 'asetools' is an "
+            "unrelated project (Aseprite tooling).\n"
+            "                Fix: pip uninstall asetools, then "
+            'pip install -e ".[neb]" from the repo root'
+        )
+    else:
+        typer.echo(
+            "asetools        not installed (optional — NEB interpolation "
+            "sanity check disabled).\n"
+            '                Enable: pip install -e ".[neb]" from the repo root'
+        )
+
+    torch_version, cuda = _torch_info()
+    typer.echo(f"torch           {torch_version or 'not installed'}")
+    typer.echo(f"CUDA            {cuda}")
+
+    typer.echo("")
+    typer.echo("MLIP packages (one env per MLIP — see ADR 0001):")
+    installed = []
+    for dist, tag in _MLIP_PACKAGES:
+        dist_version = _package_version(dist)
+        typer.echo(f"  {dist:<14} {dist_version or 'not installed'}")
+        if dist_version is not None:
+            installed.append(tag)
+
+    if len(installed) > 1:
+        typer.echo(
+            "  WARN: multiple MLIP packages in one env — their torch/e3nn "
+            "pins collide; at least one may be silently broken."
+        )
+
+    typer.echo("")
+    if installed:
+        typer.echo(f"--mlip auto resolves to: {installed[0]}")
+    else:
+        typer.echo(
+            "FAIL: no supported MLIP installed. Pick one and follow its "
+            f"install recipe in {_INSTALL_DOCS}."
+        )
+        problems.append("no MLIP")
+
+    typer.echo("")
+    if problems:
+        typer.echo(f"Environment NOT usable ({', '.join(problems)}).")
+        raise typer.Exit(code=1)
+    typer.echo("Environment OK.")

--- a/src/mlip_platform/cli/main.py
+++ b/src/mlip_platform/cli/main.py
@@ -4,6 +4,7 @@ from mlip_platform.cli.commands import (
     autoneb,
     autoneb_results,
     benchmark,
+    doctor,
     md,
     neb,
     optimize,
@@ -17,6 +18,7 @@ app.add_typer(neb.app, name="neb", help="Run NEB interpolation and relaxation")
 app.add_typer(autoneb.app, name="autoneb", help="Run AutoNEB with dynamic image insertion")
 app.add_typer(autoneb_results.app, name="autoneb-results", help="Extract and visualize AutoNEB results")
 app.add_typer(benchmark.app, name="benchmark", help="Run MLIP benchmark on a structure")
+app.command("doctor")(doctor.doctor)
 
 
 if __name__ == "__main__":

--- a/tests/test_cli_doctor.py
+++ b/tests/test_cli_doctor.py
@@ -1,0 +1,192 @@
+"""Tests for `mlip doctor` — the environment self-check command.
+
+Contract: exit code 0 iff at least one MLIP package is installed; exit
+code 1 otherwise, with a pointer at the install recipes. asetools is an
+optional extra (`.[neb]`, enables the NEB interpolation sanity check), so
+its absence is a hint, not a failure — but the PyPI name-collision impostor
+("asetools" on PyPI is unrelated Aseprite tooling) is loudly flagged with
+the recovery command.
+
+Package availability is monkeypatched through the `_package_version` and
+`_asetools_status` seams so the tests are independent of which MLIPs happen
+to be installed in the test environment.
+"""
+import subprocess
+import sys
+import types
+
+from typer.testing import CliRunner
+
+from mlip_platform.cli.commands import doctor as doctor_cmd
+from mlip_platform.cli.main import app as main_app
+
+runner = CliRunner()
+
+# Core (always-installed) distributions the doctor reports on. Anything
+# outside this set is treated as not installed in the mocked environment.
+_CORE_VERSIONS = {
+    "mlip-platform": "0.3.0",
+    "ase": "3.29.0",
+}
+
+
+def _fake_versions(extra):
+    """Build a `_package_version` replacement: core deps + `extra` dists."""
+    table = dict(_CORE_VERSIONS, **extra)
+
+    def _package_version(dist_name):
+        return table.get(dist_name)
+
+    return _package_version
+
+
+class TestDoctorHelp:
+    def test_help_exits_cleanly(self):
+        # invoke via the running interpreter, not the `mlip` script on PATH —
+        # PATH may hold an older install that predates `doctor`
+        result = subprocess.run(
+            [sys.executable, "-m", "mlip_platform.cli.main", "doctor", "--help"],
+            capture_output=True, text=True,
+        )
+        assert result.returncode == 0
+        assert "Usage" in result.stdout or "Options" in result.stdout
+
+
+class TestDoctorUsableEnvironment:
+    def test_real_asetools_plus_mace_exits_zero(self, monkeypatch):
+        monkeypatch.setattr(
+            doctor_cmd, "_package_version",
+            _fake_versions({"mace-torch": "0.3.9"}),
+        )
+        monkeypatch.setattr(doctor_cmd, "_asetools_status", lambda: "ok")
+
+        result = runner.invoke(main_app, ["doctor"])
+
+        assert result.exit_code == 0
+        assert "mace-torch" in result.output
+        assert "0.3.9" in result.output
+
+    def test_auto_detection_order_uma_wins_over_mace(self, monkeypatch):
+        monkeypatch.setattr(
+            doctor_cmd, "_package_version",
+            _fake_versions({"fairchem-core": "2.0.0", "mace-torch": "0.3.9"}),
+        )
+        monkeypatch.setattr(doctor_cmd, "_asetools_status", lambda: "ok")
+
+        result = runner.invoke(main_app, ["doctor"])
+
+        assert result.exit_code == 0
+        # detect_mlip prefers UMA over MACE; doctor must report the same tag
+        assert "uma-s-1p2" in result.output
+
+    def test_two_mlips_in_one_env_warns_but_exits_zero(self, monkeypatch):
+        monkeypatch.setattr(
+            doctor_cmd, "_package_version",
+            _fake_versions({"fairchem-core": "2.0.0", "mace-torch": "0.3.9"}),
+        )
+        monkeypatch.setattr(doctor_cmd, "_asetools_status", lambda: "ok")
+
+        result = runner.invoke(main_app, ["doctor"])
+
+        assert result.exit_code == 0
+        # ADR 0001: one env per MLIP; two packages in one env is a warning
+        assert "WARN" in result.output
+
+
+class TestDoctorBrokenEnvironment:
+    def test_no_mlip_installed_exits_one_with_recipe_pointer(self, monkeypatch):
+        monkeypatch.setattr(
+            doctor_cmd, "_package_version", _fake_versions({}),
+        )
+        monkeypatch.setattr(doctor_cmd, "_asetools_status", lambda: "ok")
+
+        result = runner.invoke(main_app, ["doctor"])
+
+        assert result.exit_code == 1
+        assert "docs/install" in result.output
+
+    def test_wrong_asetools_warns_with_recovery_command_but_exits_zero(
+        self, monkeypatch
+    ):
+        monkeypatch.setattr(
+            doctor_cmd, "_package_version",
+            _fake_versions({"mace-torch": "0.3.9"}),
+        )
+        monkeypatch.setattr(
+            doctor_cmd, "_asetools_status", lambda: "wrong-package"
+        )
+
+        result = runner.invoke(main_app, ["doctor"])
+
+        # the impostor doesn't stop MLIP runs — usable env, loud warning
+        assert result.exit_code == 0
+        assert "WARN" in result.output
+        assert "pip uninstall asetools" in result.output
+
+    def test_missing_asetools_hints_at_neb_extra_and_exits_zero(
+        self, monkeypatch
+    ):
+        monkeypatch.setattr(
+            doctor_cmd, "_package_version",
+            _fake_versions({"mace-torch": "0.3.9"}),
+        )
+        monkeypatch.setattr(doctor_cmd, "_asetools_status", lambda: "missing")
+
+        result = runner.invoke(main_app, ["doctor"])
+
+        assert result.exit_code == 0
+        assert '.[neb]' in result.output
+
+
+class TestDoctorRealEnvironment:
+    """Unmocked runs — exercise the real probe helpers on whatever env runs
+    the tests (CI has the real asetools but no MLIP; a user env may have
+    both). Assert invariants, not env-specific facts."""
+
+    def test_real_run_exit_code_is_zero_or_one(self):
+        result = runner.invoke(main_app, ["doctor"])
+        assert result.exit_code in (0, 1)
+        assert "mlip-platform" in result.output
+        assert "asetools" in result.output
+
+    def test_asetools_status_returns_known_value(self):
+        assert doctor_cmd._asetools_status() in ("ok", "wrong-package", "missing")
+
+    def test_package_version_known_and_unknown(self):
+        # mlip-platform is installed in every test env (editable install)
+        assert doctor_cmd._package_version("mlip-platform") is not None
+        assert doctor_cmd._package_version("no-such-distribution-xyz") is None
+
+    def test_torch_info_returns_version_and_cuda_fields(self):
+        version, cuda = doctor_cmd._torch_info()
+        assert version is None or isinstance(version, str)
+        assert isinstance(cuda, str)
+
+
+class TestTorchInfoBranches:
+    """CUDA branches via a stub torch — CI has no torch installed, so these
+    paths would otherwise never execute."""
+
+    def _stub_torch(self, monkeypatch, cuda_available, device_count=0):
+        fake_cuda = types.SimpleNamespace(
+            is_available=lambda: cuda_available,
+            device_count=lambda: device_count,
+        )
+        monkeypatch.setitem(
+            sys.modules, "torch", types.SimpleNamespace(cuda=fake_cuda)
+        )
+        monkeypatch.setattr(
+            doctor_cmd, "_package_version", _fake_versions({"torch": "2.5.0"})
+        )
+
+    def test_cuda_available_reports_device_count(self, monkeypatch):
+        self._stub_torch(monkeypatch, cuda_available=True, device_count=2)
+        version, cuda = doctor_cmd._torch_info()
+        assert version == "2.5.0"
+        assert "2 device(s)" in cuda
+
+    def test_cpu_only_torch_reported(self, monkeypatch):
+        self._stub_torch(monkeypatch, cuda_available=False)
+        version, cuda = doctor_cmd._torch_info()
+        assert version == "2.5.0"
+        assert "CPU only" in cuda


### PR DESCRIPTION
**Stacked on** `claude/repo-install-ease-wxxt9x` (the pyproject migration that makes asetools an optional `[neb]` extra) — merge that first; GitHub will retarget this to `main` automatically. Supersedes #30 together with the base branch.

## What this adds

**`mlip doctor`** — one-command environment verification for humans, agents, and CI. Reports Python/package versions, asetools health (distinguishes the real GitHub package from the PyPI Aseprite impostor via the `asetools.pathways` probe), the four MLIP packages, what `--mlip auto` resolves to, and torch/CUDA. Exit 0 iff at least one MLIP is installed; missing asetools is an *optional-extra hint*, the impostor is a loud WARN with the recovery command. Built test-first: 13 tests (`tests/test_cli_doctor.py`), monkeypatch seams so they're independent of what's installed.

**`AGENTS.md` + `CLAUDE.md`** — committed orientation for LLM interfaces (Claude Code, Cursor, Codex) and new users: the four-command install, one-MLIP-per-env rule, the asetools trap, gated UMA, doctor verification, test commands, frozen-goldens policy.

**README alignment** — asetools documented as the optional `[neb]` extra (the old text claimed `pip install -e .` installs it); `mlip doctor` added as Quick Start step 4. Also fixes a pre-existing contradiction: the README said "models can coexist in the same environment" while ADR 0001 and `docs/install/README.md` say the opposite — now aligned to the ADR.

**CI** — `tests.yml`/`weekly.yml` install `.[dev,neb]` instead of a manual `pip install git+…`, so CI exercises the same install path users run. New `install-smoke.yml` proves the README Quick Start on a clean runner (base install → `[neb]` extra → CPU torch + mace-torch → `mlip doctor` gate → tiny Cu relaxation asserting a finite energy), weekly + on packaging-file changes.

**pyproject** — drops the dead `typer[all]` extra (empty in typer ≥ 0.12; produced a pip warning on every fresh install).

## Verification (fresh venvs, this branch)

- `pip install -e .` (pyproject path) installs cleanly, **no** asetools in base — and the full unit subset passes without it (138 passed), confirming asetools is genuinely optional
- `pip install -e ".[neb]"` pulls the real asetools; `asetools.pathways.neb` imports
- `mlip doctor`: exit 1 + recipe pointer in a bare env; exit 0 with an MLIP present
- Full unit subset incl. doctor tests: **141 passed, 6 skipped, 5 deselected**
- No golden files touched

🤖 Generated with [Claude Code](https://claude.com/claude-code)