### PR TITLE
fix(packaging): move to pyproject.toml, asetools as optional [neb] extra

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,79 @@
+[build-system]
+requires = ["setuptools>=61.0", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "mlip-platform"
+version = "0.3.0"
+description = "CLI platform for running MLIP-based MD, NEB, and Benchmarking"
+readme = "README.md"
+requires-python = ">=3.9"
+authors = [
+    { name = "Juan M Arce-Ramos", email = "juan.arce@ihpc.a-star.edu.sg" },
+]
+classifiers = [
+    "Development Status :: 3 - Alpha",
+    "Intended Audience :: Science/Research",
+    "Topic :: Scientific/Engineering :: Chemistry",
+    "Topic :: Scientific/Engineering :: Physics",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.9",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+]
+# Base dependencies only. The MLIP backends (mace-torch, fairchem-core, sevenn,
+# chgnet) and their torch stacks are intentionally NOT listed here: they have
+# mutually incompatible pins and must be installed one-per-env via the recipes
+# in docs/install/. See ADR 0001.
+dependencies = [
+    "typer[all]",
+    "ase",
+    "pandas",
+    "matplotlib",
+    "scipy",
+]
+
+[project.optional-dependencies]
+# NEB interpolation sanity-check helper. Installed from git because the PyPI
+# name "asetools" is taken by an unrelated project (an Aseprite image tool) --
+# do NOT add a bare "asetools" to the base dependencies. The import in
+# core/neb.py is guarded, so this extra is optional; install it to enable the
+# post-interpolation atomic-distance check:
+#   pip install -e ".[neb]"
+neb = [
+    "asetools @ git+https://github.com/manuelarcer/asetools.git",
+]
+dev = [
+    "pytest",
+    "pytest-cov",
+    "diff-cover",
+    # mutmut 3.x dropped the --paths-to-mutate CLI flag and reads config from
+    # pyproject.toml ([tool.mutmut] below); pinned <3 for the flag-based CLI.
+    "mutmut>=2.4,<3.0",
+    "pip-audit",
+]
+
+[project.scripts]
+mlip = "mlip_platform.cli.main:app"
+md = "mlip_platform.cli.commands.md:app"
+neb = "mlip_platform.cli.commands.neb:app"
+autoneb = "mlip_platform.cli.commands.autoneb:app"
+autoneb-results = "mlip_platform.cli.commands.autoneb_results:app"
+benchmark = "mlip_platform.cli.commands.benchmark:app"
+optimize = "mlip_platform.cli.commands.optimize:app"
+
+[project.urls]
+Homepage = "https://github.com/manuelarcer/mlip-platform"
+Repository = "https://github.com/manuelarcer/mlip-platform"
+
+[tool.setuptools]
+package-dir = { "" = "src" }
+include-package-data = true
+zip-safe = false
+
+[tool.setuptools.packages.find]
+where = ["src"]
+
+[tool.mutmut]
+paths_to_mutate = "src/mlip_platform/"

--- a/setup.py
+++ b/setup.py
@@ -1,55 +1,6 @@
-from setuptools import setup, find_packages
+# Project metadata now lives in pyproject.toml (PEP 621).
+# This shim remains so that legacy `python setup.py` / older-pip editable
+# installs keep working; setuptools reads all fields from pyproject.toml.
+from setuptools import setup
 
-setup(
-    name="mlip-platform",
-    version="0.3.0",
-    description="CLI platform for running MLIP-based MD, NEB, and Benchmarking",
-    author="Juan M Arce-Ramos",
-    author_email="juan.arce@ihpc.a-star.edu.sg",
-    python_requires=">=3.9",
-    package_dir={"": "src"},
-    packages=find_packages(where="src"),
-    install_requires=[
-        "typer[all]",
-        "ase",
-        "pandas",
-        "matplotlib",
-        "scipy",
-        "asetools",
-    ],
-    extras_require={
-        "dev": [
-            "pytest",
-            "pytest-cov",
-            "diff-cover",
-            # mutmut 3.x dropped the --paths-to-mutate CLI flag and requires
-            # pyproject.toml config; this repo has no pyproject.toml.
-            "mutmut>=2.4,<3.0",
-            "pip-audit",
-        ],
-    },
-    classifiers=[
-        "Development Status :: 3 - Alpha",
-        "Intended Audience :: Science/Research",
-        "Topic :: Scientific/Engineering :: Chemistry",
-        "Topic :: Scientific/Engineering :: Physics",
-        "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.9",
-        "Programming Language :: Python :: 3.10",
-        "Programming Language :: Python :: 3.11",
-        "Programming Language :: Python :: 3.12",
-    ],
-    entry_points={
-        'console_scripts': [
-            'mlip = mlip_platform.cli.main:app',
-            'md = mlip_platform.cli.commands.md:app',
-            'neb = mlip_platform.cli.commands.neb:app',
-            'autoneb = mlip_platform.cli.commands.autoneb:app',
-            'autoneb-results = mlip_platform.cli.commands.autoneb_results:app',
-            'benchmark = mlip_platform.cli.commands.benchmark:app',
-            'optimize = mlip_platform.cli.commands.optimize:app',
-        ],
-    },
-    include_package_data=True,
-    zip_safe=False,
-)
+setup()


### PR DESCRIPTION
Filing this PR for the existing agent branch `claude/repo-install-ease-wxxt9x` (one commit, f05d3f4) so the stack can merge in order. **Merge this first**, then #31 (stacked on it, retargets to main automatically).

## What it does

- Migrates packaging from `setup.py` to `pyproject.toml` (PEP 621); `setup.py` remains as a compatibility shim.
- Removes `asetools` from the base dependencies. The bare PyPI name resolves to an unrelated Aseprite tool, and the only in-code usage is the guarded NEB interpolation sanity-check import (`src/mlip_platform/core/neb.py`) — so it is now an optional extra: `pip install -e ".[neb]"`, pulled from GitHub via a direct reference.
- Consequence, confirmed as intended: a plain `pip install -e .` runs NEB **without** the interpolation distance check. `mlip doctor` (#31) surfaces this state and the README (#31) documents the extra.

## Verification (done on the #31 stack, which includes this commit unchanged)

- Fresh venv `pip install -e .`: builds cleanly from pyproject, no asetools in base
- Full unit subset passes without asetools (138 passed) — the dependency is genuinely optional
- `pip install -e ".[neb]"` pulls the real asetools; `asetools.pathways.neb` imports

🤖 Generated with [Claude Code](https://claude.com/claude-code)