### PR TITLE
docs: bring README, CONTRIBUTING, CHANGELOG up to date with #31/#32

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ All notable changes to this project are documented here. Format follows [Keep a 
 
 ### Added
 
+- `mlip doctor`: environment self-check reporting package versions, asetools health (distinguishes the real GitHub package from the unrelated PyPI `asetools`), installed MLIP packages, what `--mlip auto` resolves to, and torch/CUDA status. Exits 0 iff at least one MLIP is installed, so scripts and CI can assert on it. (#31)
+- `AGENTS.md` and `CLAUDE.md`: committed orientation for AI coding assistants and new users — install rules, verification, testing commands, and repo conventions. (#31)
+- CI: `install-smoke.yml` workflow proves the README Quick Start on a clean runner (base install → `[neb]` extra → CPU MACE → `mlip doctor` gate → small relaxation with a finite-energy assertion), weekly and on packaging-file changes. (#31)
 - `optimize batch`: relax a series of structures in one process, loading the MLIP model **only once** and reusing it across every relaxation (avoids the per-run model-load cost). Discovers one input structure per immediate subdirectory of `--parent` (default `--input-name '*.vasp'`; the platform's own `*_final.vasp` outputs are ignored), relaxes each in place, continues past failures, and writes a `batch_summary.csv` into `--parent`. Supports `--skip-existing` to resume a partial batch.
 - `build_calculator()` in `mlip_platform.cli.utils`: builds and returns an ASE calculator without attaching it, so the loaded model can be reused across many structures. `setup_calculator()` is now a thin build-and-attach wrapper around it.
 - `optimize run` / `optimize batch` now also write a fixed-name `CONTCAR` (copy of the final relaxed structure) so a follow-up DFT run managed by asetools can restart from the directory.
@@ -16,6 +19,10 @@ All notable changes to this project are documented here. Format follows [Keep a 
 
 ### Changed
 
+- **Packaging moved from `setup.py` to `pyproject.toml`** (PEP 621); `setup.py` remains as a compatibility shim. (#32)
+- **asetools is no longer a base dependency.** The bare PyPI name `asetools` resolves to an unrelated Aseprite tool, and the only in-code use is the guarded NEB interpolation sanity check — so it is now an optional extra installed from GitHub: `pip install -e ".[neb]"`. A plain install runs NEB **without** the interpolation distance check (by design); `mlip doctor` reports the state. (#32, #31)
+- CI workflows install `.[dev,neb]` instead of a separate `pip install git+…` asetools step, exercising the same install path users run. (#31)
+- Dependency `typer[all]` → `typer` (the `[all]` extra is empty in modern typer and produced a pip warning on every fresh install). (#31)
 - **Plotting is now opt-in across `optimize`, `md`, and `neb`.** Previously these commands always wrote PNG figures (`optimize` had a `--no-plot` opt-out; `md`/`neb` had no way to disable it). Now no PNG is written unless `--plot` is passed. The CSV data (`*_convergence.csv`, `md_energy.csv`, `neb_convergence.csv`, `neb_data.csv`) is always written, so nothing is lost — figures can be regenerated from it. Motivation: the figure/save is IO that dominates short runs (measured ~3x speedup on frozen-surface site scans). The old `--no-plot` still works as the off side of `--plot/--no-plot`, so existing scripts are unaffected.
 - **Auto-detection order changed to UMA → MACE → SevenNet → CHGNet** (was UMA → SevenNet → MACE → CHGNet). UMA is still preferred when installed, but MACE is now the preferred fallback ahead of SevenNet/CHGNet: UMA is gated on Hugging Face and unusable without an access request, whereas `pip install mace-torch` gives a working model immediately. A fresh environment therefore lands on a usable default.
 - NEB now uses ASE's `improvedtangent` tangent method instead of the older default (`aseneb`), which improves convergence on curved reaction paths.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,16 +14,16 @@ Issue templates live under `.github/ISSUE_TEMPLATE/`.
 ```bash
 git clone https://github.com/manuelarcer/mlip-platform.git
 cd mlip-platform
-pip install -e .
+pip install -e ".[dev,neb]"   # dev = pytest + coverage tools; neb = optional asetools
 
-# Install at least one MLIP for integration tests (optional):
-pip install fairchem-core   # UMA — recommended; gated on Hugging Face
-pip install sevenn          # SevenNet
-pip install mace-torch      # MACE
-pip install chgnet          # CHGNet
+# Optionally install ONE MLIP for integration tests. One MLIP per environment —
+# the packages pin incompatible torch/e3nn versions (see docs/adr/0001-per-mlip-envs.md
+# and the recipes in docs/install/README.md):
+pip install mace-torch      # simplest — works immediately, no access request
+mlip doctor                 # verify what the environment can run
 ```
 
-The `mlip`, `optimize`, `md`, `neb`, `autoneb`, `autoneb-results`, and `benchmark` commands all become available after `pip install -e .`. See the [README](README.md) for usage and [docs/PYTHON_API.md](docs/PYTHON_API.md) for the public Python API.
+The `mlip` (including `mlip doctor`), `optimize`, `md`, `neb`, `autoneb`, `autoneb-results`, and `benchmark` commands all become available after `pip install -e .`. See the [README](README.md) for usage and [docs/PYTHON_API.md](docs/PYTHON_API.md) for the public Python API.
 
 ## Running tests
 
@@ -89,10 +89,10 @@ A separate scheduled workflow (`.github/workflows/weekly.yml`) runs broader qual
 
 ## Versioning and releases
 
-Versioning follows [Semantic Versioning](https://semver.org/). The version lives in `setup.py`. To cut a release:
+Versioning follows [Semantic Versioning](https://semver.org/). The version lives in `pyproject.toml`. To cut a release:
 
 1. Move entries from `[Unreleased]` to a new `[X.Y.Z] - YYYY-MM-DD` section in `CHANGELOG.md`.
-2. Bump the `version` string in `setup.py`.
+2. Bump the `version` string in `pyproject.toml`.
 3. Tag the commit `vX.Y.Z`.
 
 There is no automated PyPI release at present.

--- a/README.md
+++ b/README.md
@@ -34,6 +34,29 @@ Supports **UMA** (FAIRChem), **MACE**, **SevenNet** (7net), and **CHGNet** model
 
 ---
 
+## How it works
+
+```mermaid
+sequenceDiagram
+    actor User
+    participant CLI as mlip CLI
+    participant Model as MLIP calculator
+    participant Files as output files
+
+    User->>CLI: optimize / md / neb run<br/>--structure POSCAR
+    CLI->>CLI: pick model (--mlip auto)<br/>UMA→MACE→SevenNet→CHGNet
+    CLI->>Model: load model once,<br/>attach to structure
+    loop until converged
+        CLI->>Model: energy + forces
+        Model-->>CLI: results
+        CLI->>Files: trajectory + CSV
+    end
+    CLI->>Files: final structure,<br/>parameter file
+    CLI-->>User: summary
+```
+
+---
+
 ## Installation
 
 > Setting up with an AI coding assistant (Claude Code, Cursor, Codex, …)? Point it at [AGENTS.md](AGENTS.md) — it covers the install rules, verification, and repo conventions in one place.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # MLIP Platform
 
+[![Tests](https://github.com/manuelarcer/mlip-platform/actions/workflows/tests.yml/badge.svg)](https://github.com/manuelarcer/mlip-platform/actions/workflows/tests.yml)
+[![Fresh-install smoke test](https://github.com/manuelarcer/mlip-platform/actions/workflows/install-smoke.yml/badge.svg)](https://github.com/manuelarcer/mlip-platform/actions/workflows/install-smoke.yml)
+
 A modular CLI toolkit for evaluating Machine Learning Interatomic Potentials (MLIPs) via:
 
 - **Geometry Optimization**
@@ -8,7 +11,7 @@ A modular CLI toolkit for evaluating Machine Learning Interatomic Potentials (ML
 - **AutoNEB** with dynamic image insertion
 - **Benchmarking**
 
-Supports **UMA** (FAIRChem), **SevenNet** (7net), and **MACE** models with automatic detection and streamlined CLI using [Typer](https://typer.tiangolo.com/).
+Supports **UMA** (FAIRChem), **MACE**, **SevenNet** (7net), and **CHGNet** models with automatic detection and streamlined CLI using [Typer](https://typer.tiangolo.com/).
 
 ---
 
@@ -25,12 +28,15 @@ Supports **UMA** (FAIRChem), **SevenNet** (7net), and **MACE** models with autom
 - NEB with IDPP interpolation, restart support, and highly-constrained mode
 - AutoNEB with dynamic image insertion
 - CSV output for all simulations; PNG plots are opt-in via `--plot` (CSVs are always written)
+- `mlip doctor` environment self-check (installed MLIPs, asetools health, torch/CUDA)
 - Lazy imports for fast CLI startup
 - Pytest-based test suite with EMT-based unit tests and MLIP integration tests
 
 ---
 
 ## Installation
+
+> Setting up with an AI coding assistant (Claude Code, Cursor, Codex, …)? Point it at [AGENTS.md](AGENTS.md) — it covers the install rules, verification, and repo conventions in one place.
 
 ### Quick Start
 
@@ -308,6 +314,11 @@ A model that fails to load is recorded in the JSON summary with the exception me
 
 ## Testing
 
+Install the test dependencies first (`[dev]` brings pytest and the coverage tools; `[neb]` the optional asetools):
+```bash
+pip install -e ".[dev,neb]"
+```
+
 Run all unit tests (no MLIP required):
 ```bash
 pytest -m "not uma and not mace and not sevenn"
@@ -356,19 +367,19 @@ For a complete reference of every file each command writes — filename, format,
 
 - CLI powered by [`typer`](https://typer.tiangolo.com/)
 - Entry points defined in [pyproject.toml](pyproject.toml) (`[project.scripts]`):
-  ```python
-  console_scripts = [
-      "md = mlip_platform.cli.commands.md:app",
-      "neb = mlip_platform.cli.commands.neb:app",
-      "optimize = mlip_platform.cli.commands.optimize:app",
-      "autoneb = mlip_platform.cli.commands.autoneb:app",
-      "autoneb-results = mlip_platform.cli.commands.autoneb_results:app",
-      "benchmark = mlip_platform.cli.commands.benchmark:app",
-  ]
+  ```toml
+  [project.scripts]
+  mlip = "mlip_platform.cli.main:app"
+  md = "mlip_platform.cli.commands.md:app"
+  neb = "mlip_platform.cli.commands.neb:app"
+  autoneb = "mlip_platform.cli.commands.autoneb:app"
+  autoneb-results = "mlip_platform.cli.commands.autoneb_results:app"
+  benchmark = "mlip_platform.cli.commands.benchmark:app"
+  optimize = "mlip_platform.cli.commands.optimize:app"
   ```
 - Lazy imports for fast CLI startup (no heavy dependencies loaded until needed)
-- All simulation outputs saved in same directory as input structure
-- Automatic plot generation for all trajectory-based calculations
+- Output locations: `optimize`/`md` write next to the input structure; `neb`/`autoneb` write into the current working directory (see [OUTPUTS.md](docs/OUTPUTS.md))
+- Plots are opt-in via `--plot`; CSV data is always written
 - Shared utilities in `core/utils.py` (fmax calculation, unit conversions)
 - Parameter I/O in `core/params_io.py` (reduces duplication across commands)
 - Optional integration with [asetools](https://github.com/manuelarcer/asetools) for NEB interpolation sanity checks (`pip install -e ".[neb]"`; the import in `core/neb.py` is guarded, so the platform runs without it)
@@ -377,7 +388,7 @@ For a complete reference of every file each command writes — filename, format,
 
 ## Changelog
 
-Release notes are tracked in [CHANGELOG.md](CHANGELOG.md). Current version: **0.3.0** (`setup.py`).
+Release notes are tracked in [CHANGELOG.md](CHANGELOG.md). Current version: **0.3.0** (`pyproject.toml`).
 
 ## Contributing
 

--- a/docs/windows_setup_guide.md
+++ b/docs/windows_setup_guide.md
@@ -187,6 +187,7 @@ Successfully installed ase-3.26.0 click-8.1.8 ... mlip-platform-0.2.0
 | `autoneb --help` | AutoNEB with dynamic image insertion |
 | `autoneb-results --help` | Extract / plot results from a completed AutoNEB run |
 | `benchmark --help` | MACE / SevenNet timing benchmarks |
+| `mlip doctor` | Environment self-check: installed MLIPs, torch/CUDA, asetools health. Exits with an error until an MLIP is installed (next section) — that is expected at this stage. |
 
 `mlip <name>` is equivalent to running `<name>` directly — for example, `mlip md run --structure POSCAR` and `md run --structure POSCAR` do the same thing. Use whichever you prefer.
 


### PR DESCRIPTION
Documentation currency pass after the install overhaul (#31, #32). No code changes.

## README
- **CI badges** for Tests and the Fresh-install smoke test — the "does a fresh install work today?" signal is now visible at the top of the repo.
- **AGENTS.md pointer** in the Installation section for users setting up via an AI coding assistant.
- CHGNet added to the supported-models line (it was missing).
- `mlip doctor` listed in Key Features.
- Testing section now starts with `pip install -e ".[dev,neb]"` (pytest/coverage tools weren't mentioned anywhere in the README).
- Developer Notes: entry points shown as the real pyproject `[project.scripts]` TOML (was the old setup.py Python list, missing `mlip`); fixed two stale bullets — "all outputs saved next to input" (neb/autoneb write to cwd) and "automatic plot generation" (plotting is opt-in since #28).
- Changelog line: version location `setup.py` → `pyproject.toml`.

## CONTRIBUTING
- Dev setup installs `.[dev,neb]` and **one** MLIP per environment — the old block told contributors to `pip install` all four MLIPs back-to-back, which directly contradicts ADR 0001 (their torch/e3nn pins collide).
- `mlip doctor` added to the setup flow and command list.
- Release steps point at `pyproject.toml` (version no longer lives in `setup.py`).

## CHANGELOG
- Unreleased entries for #32 (pyproject migration, asetools → optional `[neb]` extra) and #31 (doctor, AGENTS.md/CLAUDE.md, install-smoke CI, typer[all] cleanup).

## Windows guide
- `mlip doctor` added to the verify-installation table (with a note that it exits non-zero until an MLIP is installed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)