### PR TITLE
docs: add the missing create-a-venv step to every install entry point

### DIFF
--- a/.github/workflows/install-smoke.yml
+++ b/.github/workflows/install-smoke.yml
@@ -26,11 +26,15 @@ jobs:
         with:
           python-version: "3.11"
 
-      - name: Base install (exact README Quick Start path)
+      - name: Base install (exact README Quick Start path, venv included)
         run: |
+          python3 -m venv .venv
+          source .venv/bin/activate
           python -m pip install --upgrade pip
           pip install -e .
           mlip --help
+          # every later step uses the venv's binaries, like an activated shell
+          echo "$PWD/.venv/bin" >> "$GITHUB_PATH"
 
       - name: "[neb] extra pulls the real asetools (not the PyPI impostor)"
         run: |

--- a/.gitignore
+++ b/.gitignore
@@ -40,6 +40,11 @@ opt_final.vasp
 tests/fixtures/structures/**/[0-9][0-9]/
 
 
+# Virtual environments (README Quick Start creates .venv in the repo)
+.venv/
+venv/
+.venv-*/
+
 # Packaging and build artifacts
 *.egg-info/
 build/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,6 +17,8 @@ vocabulary (MLIP tag vs package vs env) — read it before discussing installs.
 ```bash
 git clone https://github.com/manuelarcer/mliprun.git
 cd mliprun
+python3 -m venv .venv && source .venv/bin/activate   # REQUIRED: bare pip fails
+                          # on PEP 668 (externally-managed) system Pythons
 pip install -e .          # base install: CLI + ASE, no MLIP yet
 pip install mace-torch    # simplest working MLIP (no access request needed)
 mlip doctor               # verify: exits 0 when the env is usable

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,6 +14,7 @@ Issue templates live under `.github/ISSUE_TEMPLATE/`.
 ```bash
 git clone https://github.com/manuelarcer/mliprun.git
 cd mliprun
+python3 -m venv .venv && source .venv/bin/activate   # or a conda env — never system Python
 pip install -e ".[dev,neb]"   # dev = pytest + coverage tools; neb = optional asetools
 
 # Optionally install ONE MLIP for integration tests. One MLIP per environment —

--- a/README.md
+++ b/README.md
@@ -69,7 +69,15 @@ git clone https://github.com/manuelarcer/mliprun.git
 cd mliprun
 ```
 
-2. **Install the package**
+2. **Create and activate a virtual environment** (don't skip this)
+```bash
+python3 -m venv .venv
+source .venv/bin/activate        # Windows PowerShell: .venv\Scripts\activate
+```
+
+Installing into the system Python fails outright on modern Linux/macOS (`error: externally-managed-environment`) and, where it doesn't, pollutes system packages. A dedicated environment is also how this project isolates MLIPs from each other (one MLIP per environment — [ADR 0001](docs/adr/0001-per-mlip-envs.md)). Prefer conda, or setting up on an HPC/GPU machine? Use the per-MLIP recipes in [docs/install/](docs/install/README.md) instead — they include tested conda and venv blocks.
+
+3. **Install the package** (into the activated environment)
 ```bash
 pip install -e .
 ```
@@ -81,7 +89,7 @@ pip install -e ".[neb]"
 
 > **Warning**: Never `pip install asetools` directly — the package named `asetools` on PyPI is an unrelated project (Aseprite tooling). The `[neb]` extra pulls the correct one from GitHub. If the wrong one is already installed: `pip uninstall asetools`, then `pip install -e ".[neb]"`.
 
-3. **Install an MLIP model** (each in its own environment — see [install recipes](docs/install/README.md))
+4. **Install an MLIP model** (each in its own environment — see [install recipes](docs/install/README.md))
 
 ```bash
 # MACE - readily usable, no access request (good default for a fresh setup)
@@ -97,7 +105,7 @@ pip install sevenn
 pip install chgnet
 ```
 
-4. **Verify the install**
+5. **Verify the install**
 ```bash
 mlip doctor
 ```


### PR DESCRIPTION
Gap spotted by Juan: no install entry point told the user to create a virtual environment.

## Why this is a defect, not a style choice

- On PEP 668 ("externally-managed") system Pythons — modern Ubuntu/Debian, Homebrew macOS — the literal Quick Start fails at `pip install -e .` with `error: externally-managed-environment`. Where it doesn't fail, it pollutes system site-packages.
- Environments are this project's MLIP-isolation mechanism (ADR 0001), so the step is structurally required.
- The per-MLIP recipes (`docs/install/`) and the Windows guide already create envs; only README Quick Start, AGENTS.md, and CONTRIBUTING skipped it.
- CI never caught it because GitHub's `setup-python` interpreter is not externally managed — the smoke test now creates a venv and runs everything through it, so CI follows the literal README path.

## Changes

- **README Quick Start**: new step 2 — `python3 -m venv .venv` + activate (Windows PowerShell variant included), with the PEP 668 rationale and a conda/HPC pointer to the per-MLIP recipes; steps renumbered 1–5.
- **AGENTS.md** and **CONTRIBUTING**: venv line added to their install blocks.
- **.gitignore**: `.venv/`, `venv/` (the Quick Start now creates one inside the repo).
- **install-smoke.yml**: base install runs inside a venv; its `bin` is exported to `GITHUB_PATH` so all later steps (MACE install, doctor gate, relaxation) use it — the smoke run on this very PR validates the new path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)