### PR TITLE
release: 0.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project are documented here. Format follows [Keep a 
 
 ## [Unreleased]
 
+_Nothing yet._
+
+## [0.4.0] - 2026-07-14
+
 ### Added
 
 - `mlip doctor`: environment self-check reporting package versions, asetools health (distinguishes the real GitHub package from the unrelated PyPI `asetools`), installed MLIP packages, what `--mlip auto` resolves to, and torch/CUDA status. Exits 0 iff at least one MLIP is installed, so scripts and CI can assert on it. (#31)
@@ -122,7 +126,8 @@ Initial public iteration.
 
 The 0.1 series predates this CHANGELOG; entries are reconstructed from the git history. There was no formal 0.1.0 release tag; `setup.py` jumped from project inception to `0.2.0` during the 2026-03-13 refactor.
 
-[Unreleased]: https://github.com/manuelarcer/mliprun/compare/v0.3.0...HEAD
+[Unreleased]: https://github.com/manuelarcer/mliprun/compare/v0.4.0...HEAD
+[0.4.0]: https://github.com/manuelarcer/mliprun/releases/tag/v0.4.0
 [0.3.0]: https://github.com/manuelarcer/mliprun/releases/tag/v0.3.0
 [0.2.0]: https://github.com/manuelarcer/mliprun/releases/tag/v0.2.0
-[0.1.0]: https://github.com/manuelarcer/mlip-platform/releases/tag/v0.1.0
+[0.1.0]: https://github.com/manuelarcer/mliprun/releases/tag/v0.1.0

--- a/README.md
+++ b/README.md
@@ -419,7 +419,7 @@ For a complete reference of every file each command writes — filename, format,
 
 ## Changelog
 
-Release notes are tracked in [CHANGELOG.md](CHANGELOG.md). Current version: **0.3.0** (`pyproject.toml`).
+Release notes are tracked in [CHANGELOG.md](CHANGELOG.md). Current version: **0.4.0** (`pyproject.toml`).
 
 ## Contributing
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mliprun"
-version = "0.3.0"
+version = "0.4.0"
 description = "CLI platform for running MLIP-based MD, NEB, and Benchmarking"
 readme = "README.md"
 requires-python = ">=3.9"


### PR DESCRIPTION
Cuts the 0.4.0 release per CONTRIBUTING's release steps — everything currently in `[Unreleased]` (pyproject migration, asetools `[neb]` extra, `mlip doctor`, AGENTS.md, install-smoke CI, the mliprun rename, venv-first docs, `optimize batch`, NEB/MD additions) becomes `[0.4.0] - 2026-07-14`.

- `pyproject.toml`: `version = "0.4.0"`
- `CHANGELOG.md`: Unreleased → 0.4.0 section; fresh empty Unreleased on top; compare/tag links updated (also fixes the `[0.1.0]` link still pointing at the old repo name — missed by the rename sweep)
- `README.md`: current-version line

**After merging**: the `v0.4.0` tag goes on the merge commit on main — I'll push it once this lands (tagging the branch commit would be wrong; squash-merge discards it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)