### PR TITLE
docs(changelog): drop the dead 0.1.0 tag link

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -130,4 +130,3 @@ The 0.1 series predates this CHANGELOG; entries are reconstructed from the git h
 [0.4.0]: https://github.com/manuelarcer/mliprun/releases/tag/v0.4.0
 [0.3.0]: https://github.com/manuelarcer/mliprun/releases/tag/v0.3.0
 [0.2.0]: https://github.com/manuelarcer/mliprun/releases/tag/v0.2.0
-[0.1.0]: https://github.com/manuelarcer/mliprun/releases/tag/v0.1.0


### PR DESCRIPTION
The changelog footer linked `[0.1.0]` to `releases/tag/v0.1.0`, but that tag never existed — the changelog's own 0.1.0 section notes there was no formal 0.1.0 release tag (`setup.py` jumped from inception to 0.2.0 in the 2026-03-13 refactor). The link 404'd and contradicted the prose, so it's removed; the `## [0.1.0]` heading stays as a plain section.

Context: retroactive tags `v0.3.0` (4f544c1, the 0.3.0 release commit) and `v0.2.0` (83fdf09, the refactor that bumped to 0.2.0) were pushed alongside this PR, so the remaining footer links all resolve now.

🤖 Generated with [Claude Code](https://claude.com/claude-code)