### PR TITLE
chore(deps): cap typer below 0.28

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,9 +27,17 @@ classifiers = [
 # mutually incompatible pins and must be installed one-per-env via the recipes
 # in docs/install/. See ADR 0001.
 dependencies = [
-    # plain "typer" — the [all] extra is empty in modern typer (>=0.12 bundles
-    # rich and shellingham) and only produces a pip warning on fresh installs
-    "typer",
+    # Upper bound is deliberate. typer >=0.16 vendors its own copy of click
+    # (typer._click), so a command's ctx yields typer._click ParameterSource
+    # members rather than click's — which silently broke param_sources_from_ctx
+    # once CI resolved a newer typer than the one developed against (see the
+    # name-keyed _SOURCE_LABELS in cli/utils.py). The code handles that split,
+    # but the cap stops an UNTESTED future typer from arriving unnoticed: CI
+    # keeps validating the newest allowed version, and raising the ceiling is a
+    # deliberate act that re-runs the suite. 0.27 is the newest version CI has
+    # green-lit. The [all] extra is empty in modern typer (>=0.12 bundles rich
+    # and shellingham) and only produces a pip warning on fresh installs.
+    "typer>=0.20,<0.28",
     "ase",
     "pandas",
     "matplotlib",


### PR DESCRIPTION
## Why

typer >=0.16 vendors its own copy of click (`typer._click`). A command's `ctx.get_parameter_source(...)` therefore returns a `typer._click.core.ParameterSource` member, a different enum class than top-level `click.core.ParameterSource`. On #38 this silently broke `param_sources_from_ctx` when CI resolved typer 0.27 (the branch was developed against 0.20) — every parameter came back `unspecified`. Fixed there by name-keying `_SOURCE_LABELS`.

The code now survives the split, but `typer` was **unpinned**, so any future typer release lands on a fresh install with no warning. This caps it.

## What

`"typer"` → `"typer>=0.20,<0.28"`.

- **Allowed:** 0.20 (local dev) through 0.27.x (newest version CI has green-lit).
- **Blocked:** 0.28+ until someone raises the ceiling deliberately — which re-runs the full suite, so a breaking change surfaces as a red build on *that* PR instead of silently on an unrelated one.

CI continues to install the newest *allowed* typer (0.27.x), so it keeps exercising the vendored-click path this pin exists to protect.

## Not touched

`ase` is also unpinned and moved 3.26→3.29 in CI without issue; left alone to keep this to one concern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)