### PR TITLE
feat: carry the MLIP head/task in the run record (schema v2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,24 @@ All notable changes to this project are documented here. Format follows [Keep a 
 
 ## [Unreleased]
 
-- Run record (`mliprun_run.json`) now records `uma_task` / `mace_head` in its
-  `provenance` block, so the record identifies the level of theory on its own.
-  Schema version 2.
+### Changed
+
+- **Run record schema `1` → `2`.** `mliprun_run.json` now records the head/task
+  that actually ran (`provenance.uma_task` / `provenance.mace_head`), so the
+  record identifies the level of theory on its own — a model tag alone does
+  not, because the heads are independent fine-tunes with independent energy
+  zeros. Each field is recorded only for its own model family, so a MACE run
+  is never labelled with the `--uma-task` its command line happened to carry.
+  `run_optimization`, `run_md` and `CustomNEB` accept the head/task as
+  keywords; `optimize`, `md`, `neb` and `autoneb` forward what they parsed.
+  Consumers that pin `schema_version == 1` must be updated.
+- An appended stage whose provenance carries a field the stored record has no
+  key for (resuming a run that started under schema 1) reports it under
+  `stage_provenance_new_fields`, meaning "this field is new; stage 0's value
+  was not recorded". Previously such a field landed in `stage_provenance`,
+  which claims the value *changed* — so a same-head resume of a legacy run
+  wrongly asserted the head had switched. `schema_version` is left as stage 0
+  wrote it; see [docs/OUTPUTS.md](docs/OUTPUTS.md#stages).
 
 ## [0.4.0] - 2026-07-14
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,9 @@ All notable changes to this project are documented here. Format follows [Keep a 
 
 ## [Unreleased]
 
-_Nothing yet._
+- Run record (`mliprun_run.json`) now records `uma_task` / `mace_head` in its
+  `provenance` block, so the record identifies the level of theory on its own.
+  Schema version 2.
 
 ## [0.4.0] - 2026-07-14
 

--- a/docs/OUTPUTS.md
+++ b/docs/OUTPUTS.md
@@ -180,14 +180,14 @@ layer — so a script that calls `run_optimization` directly gets one too.
 
 | Key | Meaning |
 |-----|---------|
-| `schema_version` | Currently `1`. Check it before parsing. |
+| `schema_version` | Currently `2`. Check it before parsing. Version 2 added `provenance.uma_task` and `provenance.mace_head`; in a version-1 record those keys are simply absent, which is not the same as null. |
 | `command` | `optimize`, `md`, `neb` or `autoneb`. |
 | `status` | Status of the **latest** stage: `running`, `converged`, `not_converged` or `failed`. A record left saying `running` means the job died without reporting back. |
 | `run.mode` | `one-off` or `batch`. |
 | `run.batch` | `null` for one-off runs; otherwise `batch_id`, `driver`, `argv`, `root`, `config_file`. Every run of one batch shares a `batch_id`. |
 | `inputs` | For `optimize` and `md`: structure filename and absolute path, atom count, formula. For `neb` and `autoneb`: `n_images` and `n_atoms` (there is no single input structure). |
 | `parameters` | Every resolved parameter as `{"value": ..., "source": ...}`. |
-| `provenance` | Versions (mliprun, ASE, the MLIP package), model, requested vs resolved device, Python, hostname, timestamps, wall time. Always describes stage 0's environment — see below. |
+| `provenance` | Versions (mliprun, ASE, the MLIP package), model **and the head/task it ran** (`uma_task` / `mace_head`), requested vs resolved device, Python, hostname, timestamps, wall time. Always describes stage 0's environment — see below. |
 | `stages` | One entry per invocation in this directory. A NEB restart or MD resume **appends**. |
 
 `provenance` is fixed at stage 0 and is never rewritten by a later stage.
@@ -197,6 +197,22 @@ stage's** `walltime_s` — compute actually spent, not the wall-clock span
 between `started_at` and `finished_at`. A NEB restarted a week after stage 0
 reports the two hours of compute the two stages took, not the week of
 wall-clock gap in between.
+
+#### The head/task fields
+
+`provenance.uma_task` and `provenance.mace_head` name the head that actually
+ran, so the record identifies the level of theory on its own — a model tag
+alone does not, because the heads are independent fine-tunes with independent
+energy zeros. At most one is ever non-null: each is recorded only when the
+model tag belongs to its family (`uma-*` and `mace-mh-*` respectively), so a
+MACE run never inherits the `--uma-task` its command line happened to carry.
+Both are `null` for models with no head at all (CHGNet, SevenNet, plain
+`mace`), and `null` also means "not determined" for a library caller that
+passed neither.
+
+Use these two fields before combining energies from different directories: an
+energy produced under one head must not enter a formula with an energy
+produced under another.
 
 ### Parameter sources
 
@@ -224,12 +240,34 @@ A stage carrying `"prior_history_unknown": true` was appended to a directory
 with no readable prior record — an older run, or one whose record was damaged.
 
 An appended stage that ran in a different environment than stage 0 — a
-restart moved to another cluster, or run after a version bump — carries a
-`stage_provenance` object holding **only** the fields that differ from the
-top-level `provenance`, drawn from `mliprun_version`, `hostname`,
-`device_resolved` and `mlip_model`. The key is omitted entirely when nothing
-differs, and stage 0 never carries it (there is nothing yet to compare it
-against).
+restart moved to another cluster, run after a version bump, or **switched to
+a different head** — carries a `stage_provenance` object holding **only** the
+fields that differ from the top-level `provenance`, drawn from
+`mliprun_version`, `hostname`, `device_resolved`, `mlip_model`, `uma_task`
+and `mace_head`. The key is omitted entirely when nothing differs, and stage 0
+never carries it (there is nothing yet to compare it against).
+
+A stage may also carry `stage_provenance_new_fields`. It means something
+different, and the two never overlap:
+
+| Key | Claim |
+|-----|-------|
+| `stage_provenance` | This field **changed**. Stage 0's value is in the top-level `provenance`; this stage's value is here. |
+| `stage_provenance_new_fields` | This field is **new**. The stored record has no key for it at all, so stage 0's value was **not recorded** and is not knowable from this file. This stage's value is here. |
+
+In practice `stage_provenance_new_fields` appears when a run started under
+schema 1 (before `uma_task`/`mace_head` existed) is resumed by a current
+mliprun. Read it as "the head is now *X*; what stage 0 ran is unrecorded" —
+**not** as "the head changed to *X*". The `*_params.txt` file written
+alongside the record by stage 0 is the remaining evidence of what stage 0
+actually used; check it before combining the two stages' energies.
+
+Such a record is a hybrid: `schema_version` stays at the value stage 0 wrote
+(`1`), while the appended stage carries a schema-2 key. The version is
+deliberately not rewritten — bumping it would assert that stage 0's
+provenance was collected under schema 2, which it was not. Parse defensively:
+treat `schema_version` as describing the top-level `provenance` block, and
+read each stage's own keys for what that stage recorded.
 
 ### Results by command
 

--- a/docs/PYTHON_API.md
+++ b/docs/PYTHON_API.md
@@ -84,6 +84,7 @@ converged = run_optimization(
     relax_cell=False,   # True → also relax the cell (VASP ISIF=3-equivalent)
     output_dir="./relaxed",
     model_name="uma-s-1p2",
+    uma_task="omat",    # or mace_head="omat_pbe" — see "Run-record keywords"
     plot=False,         # default: no PNG. Set True to write *_convergence.png (CSV always written)
 )
 ```
@@ -123,6 +124,7 @@ run_md(
     traj_interval=100,  # frames written to md.traj every N steps
     output_dir="./md",
     model_name="uma-s-1p2",
+    uma_task="omat",    # or mace_head="omat_pbe" — see "Run-record keywords"
 )
 ```
 
@@ -148,6 +150,33 @@ dyn.run(50000)
 `setup_dynamics` returns the corresponding ASE dynamics object (`Langevin`, `NoseHoover`, `NVTBerendsen`, `NPT`, `NPTBerendsen`, or `VelocityVerlet`). It is also where Maxwell-Boltzmann velocity initialization happens for NVT/NPT.
 
 For the full parameter list and unit conventions, see [MD_REFERENCE.md](MD_REFERENCE.md).
+
+---
+
+## Run-record keywords
+
+`run_optimization` and `run_md` both write a `mliprun_run.json` run record
+([OUTPUTS.md](OUTPUTS.md#the-run-record)). These keywords exist only to fill
+it in — none of them changes the physics — and all are optional:
+
+| Keyword | Default | Notes |
+|---------|---------|-------|
+| `uma_task` | `None` | The UMA task head this run used. Recorded only when `model_name` starts with `uma-`. |
+| `mace_head` | `None` | The MACE head this run used. Recorded only when `model_name` starts with `mace-mh-`. |
+| `device_requested` | `"auto"` | The device as asked for. |
+| `device_resolved` | `"auto"` | The device actually used (e.g. `"cuda"`). |
+| `run_context` | `None` | A `RunContext` declaring the command, batch identity, and where each parameter value came from. Without it every parameter is tagged `unspecified` — mliprun never guesses. |
+
+Pass the same head/task you gave `setup_calculator` / `build_calculator`.
+These functions receive an `Atoms` object with a calculator already attached
+and cannot interrogate it for the head, so an omitted `uma_task` is recorded
+as "not determined" rather than guessed — CANON C1: the head is an explicit
+decision, never inferred. The mismatched one is dropped rather than trusted,
+so passing both is harmless.
+
+The record is what lets you check, later, that two energies you are about to
+subtract came from the same head. Filling these in is the difference between
+a record that identifies the level of theory and one that does not.
 
 ---
 

--- a/docs/superpowers/plans/2026-07-29-run-record-head-provenance.md
+++ b/docs/superpowers/plans/2026-07-29-run-record-head-provenance.md
@@ -1,0 +1,536 @@
+# Run Record Head/Task Provenance Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make `mliprun_run.json` name the MLIP head/task that actually ran, so the record can identify the level of theory on its own.
+
+**Architecture:** Two nullable fields (`uma_task`, `mace_head`) added to the `provenance` block of the run record, populated through `collect_provenance` and gated there by model-tag family so a caller passing an inapplicable default cannot mislabel a run. `SCHEMA_VERSION` goes 1 → 2 so readers can distinguish an old record from a genuinely-null field. Both fields join `_PROVENANCE_DIFF_FIELDS` so a resume that switches head is recorded.
+
+**Tech Stack:** Python 3.9+, ASE, typer CLI, pytest.
+
+**Spec:** `docs/superpowers/specs/2026-07-29-run-record-head-provenance-design.md`
+
+## Global Constraints
+
+- **Branch:** `feat/run-record-head-provenance` (already created, spec already committed on it). Draft PRs only; never push to `main`. One concern per PR.
+- **Never regenerate golden reference files** (`tests/goldens/*.json`). If a golden test fails, report the numerical delta; updating baselines is a human decision. This change touches no numerics, so no golden should move.
+- **CI gates:** full unit suite plus diff coverage ≥ 90% on changed lines. Every new line needs a test that reaches it.
+- **Every test must assert a numerical value or invariant.** No smoke-only tests.
+- Test command (no MLIP required): `pytest -m "not uma and not mace and not sevenn"`
+- Code style: typer CLI, lazy imports for heavy packages, NumPy-style docstrings.
+- `uma_task` is non-null only for models whose tag starts with `uma-`; `mace_head` only for tags starting with `mace-mh-`. Enforced inside `collect_provenance`, not at call sites.
+
+---
+
+### Task 1: Head fields, schema bump, diff fields
+
+**Files:**
+- Modify: `src/mliprun/core/run_record.py:32` (`SCHEMA_VERSION`), `:52` (`_PROVENANCE_DIFF_FIELDS`), `:159-204` (`collect_provenance`)
+- Test: `tests/test_run_record.py`
+
+**Interfaces:**
+- Consumes: nothing from earlier tasks.
+- Produces: `collect_provenance(*, mlip_model, device_requested, device_resolved, uma_task=None, mace_head=None) -> dict` — returned dict gains keys `"uma_task"` and `"mace_head"`, both always present, `None` when the model family does not match. `SCHEMA_VERSION == 2`.
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to `tests/test_run_record.py`. The existing module-level helpers `_read(tmp_path)` and `_begin(tmp_path, **kwargs)` are already defined at the top of that file — reuse them.
+
+```python
+class TestHeadProvenance:
+    """CANON C1/C3: the head/task is its own decision and must never be
+    inferred. A record naming only the model tag cannot identify the level
+    of theory."""
+
+    def test_head_fields_default_to_none(self):
+        prov = collect_provenance(mlip_model="chgnet", device_requested="cpu",
+                                  device_resolved="cpu")
+        assert prov["uma_task"] is None
+        assert prov["mace_head"] is None
+
+    def test_records_uma_task_for_uma_model(self):
+        prov = collect_provenance(mlip_model="uma-s-1p2", device_requested="cuda",
+                                  device_resolved="cuda", uma_task="oc25")
+        assert prov["uma_task"] == "oc25"
+        assert prov["mace_head"] is None
+
+    def test_records_mace_head_for_mace_model(self):
+        prov = collect_provenance(mlip_model="mace-mh-1", device_requested="cpu",
+                                  device_resolved="cpu", mace_head="omat_pbe")
+        assert prov["mace_head"] == "omat_pbe"
+        assert prov["uma_task"] is None
+
+    def test_drops_head_that_does_not_match_the_model_family(self):
+        """A CLI passes its parsed --uma-task unconditionally, defaults
+        included. A MACE run must not inherit a UMA task it never used."""
+        prov = collect_provenance(mlip_model="mace-mh-1", device_requested="cpu",
+                                  device_resolved="cpu", uma_task="omat",
+                                  mace_head="omat_pbe")
+        assert prov["uma_task"] is None
+        assert prov["mace_head"] == "omat_pbe"
+
+    def test_tolerates_non_string_model(self):
+        prov = collect_provenance(mlip_model=None, device_requested="cpu",
+                                  device_resolved="cpu", uma_task="omat")
+        assert prov["uma_task"] is None
+        assert prov["mace_head"] is None
+
+
+class TestSchemaVersion:
+    def test_schema_version_is_two(self):
+        """Bumped so a reader can tell 'no uma_task key because the record
+        predates the field' from 'uma_task is null because it was MACE'."""
+        assert SCHEMA_VERSION == 2
+
+    def test_written_record_carries_the_new_version(self, tmp_path):
+        _begin(tmp_path)
+        assert _read(tmp_path)["schema_version"] == 2
+
+
+class TestHeadInStageProvenance:
+    def test_append_records_a_switched_head(self, tmp_path):
+        """C3 forbids mixing heads within an energy formula, so a resume
+        that switches head is exactly what must not go unrecorded."""
+        base = {"mliprun_version": "0.4.0", "hostname": "node-a",
+                "device_resolved": "cuda", "mlip_model": "uma-s-1p2",
+                "uma_task": "omat", "mace_head": None}
+        rec = _begin(tmp_path, provenance=dict(base))
+        rec.complete(status="converged")
+
+        rec2 = _begin(tmp_path, provenance=dict(base, uma_task="oc25"),
+                      append=True)
+        rec2.complete(status="converged")
+
+        data = _read(tmp_path)
+        assert data["stages"][1]["stage_provenance"] == {"uma_task": "oc25"}
+        assert data["provenance"]["uma_task"] == "omat"
+
+    def test_append_with_same_head_writes_no_stage_provenance(self, tmp_path):
+        base = {"mliprun_version": "0.4.0", "hostname": "node-a",
+                "device_resolved": "cuda", "mlip_model": "uma-s-1p2",
+                "uma_task": "omat", "mace_head": None}
+        rec = _begin(tmp_path, provenance=dict(base))
+        rec.complete(status="converged")
+        rec2 = _begin(tmp_path, provenance=dict(base), append=True)
+        rec2.complete(status="converged")
+        assert "stage_provenance" not in _read(tmp_path)["stages"][1]
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `pytest tests/test_run_record.py -k "HeadProvenance or SchemaVersion or HeadInStage" -v`
+Expected: FAIL — `TypeError: collect_provenance() got an unexpected keyword argument 'uma_task'`, and `assert 1 == 2` for the schema version.
+
+- [ ] **Step 3: Bump the schema version**
+
+In `src/mliprun/core/run_record.py`, change line 32:
+
+```python
+SCHEMA_VERSION = 2
+```
+
+- [ ] **Step 4: Extend the provenance diff fields**
+
+Replace the `_PROVENANCE_DIFF_FIELDS` definition (currently line 52), keeping the existing comment above it:
+
+```python
+_PROVENANCE_DIFF_FIELDS = ("mliprun_version", "hostname", "device_resolved",
+                           "mlip_model", "uma_task", "mace_head")
+```
+
+- [ ] **Step 5: Add the head parameters to `collect_provenance`**
+
+Change the signature (currently lines 159-160) to:
+
+```python
+def collect_provenance(*, mlip_model: Any, device_requested: str,
+                        device_resolved: str, uma_task: Optional[str] = None,
+                        mace_head: Optional[str] = None) -> dict:
+```
+
+Append to the existing docstring, before the closing quotes:
+
+```
+    ``uma_task`` and ``mace_head`` are gated on the model tag rather than
+    trusted from the caller: CLIs pass whatever their ``--uma-task`` /
+    ``--mace-head`` options resolved to, defaults included, so a MACE run
+    would otherwise be recorded as carrying a UMA task it never used.
+    CANON C1 makes the head its own explicit decision and C3 forbids mixing
+    heads within an energy formula, so a wrong head is worse than none.
+```
+
+Immediately before the `return {` statement (currently line 192), add:
+
+```python
+    tag = mlip_model if isinstance(mlip_model, str) else ""
+```
+
+Inside the returned dict, directly after the `"mlip_model": mlip_model,` entry, add:
+
+```python
+        "uma_task": uma_task if tag.startswith("uma-") else None,
+        "mace_head": mace_head if tag.startswith("mace-mh-") else None,
+```
+
+- [ ] **Step 6: Run the tests to verify they pass**
+
+Run: `pytest tests/test_run_record.py -v`
+Expected: PASS, including every pre-existing test in the file.
+
+- [ ] **Step 7: Run the full unit suite**
+
+Run: `pytest -m "not uma and not mace and not sevenn"`
+Expected: PASS. If any golden test fails, STOP and report the numerical delta — do not regenerate.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add src/mliprun/core/run_record.py tests/test_run_record.py
+git commit -m "feat(run-record): carry uma_task/mace_head, schema v2
+
+collect_provenance took only the model tag, so a record named uma-s-1p2
+without the oc25 task that actually ran. CANON C1 makes the head its own
+explicit decision and C3 forbids mixing heads within an energy formula,
+so the record could not serve as provenance for any energy entering a
+formula.
+
+Both fields are gated on the model tag inside collect_provenance rather
+than trusted from callers, which pass their parsed option defaults
+unconditionally. SCHEMA_VERSION 1 -> 2 so a reader can distinguish an
+old record from a genuinely-null field, and both fields join
+_PROVENANCE_DIFF_FIELDS so a resume that switches head is recorded.
+
+Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 2: Thread the head through the core engines
+
+**Files:**
+- Modify: `src/mliprun/core/optimize.py:44-56` (signature), `:152-156` (`collect_provenance` call)
+- Modify: `src/mliprun/core/md.py:213-239` (signature), `:323-327` (`collect_provenance` call)
+- Modify: `src/mliprun/core/neb.py:662-666` and `:815-819` (both `collect_provenance` calls)
+- Test: `tests/test_core_md.py`, `tests/test_core_optimize.py`
+
+**Interfaces:**
+- Consumes: `collect_provenance(..., uma_task=None, mace_head=None)` from Task 1.
+- Produces: `run_optimization(...)` and `run_md(...)` both accept keyword-only-by-convention `uma_task: Optional[str] = None, mace_head: Optional[str] = None` appended after `device_resolved`. `CustomNEB` needs no new attributes — it already stores `self.uma_task` and `self.mlip`.
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to `tests/test_core_md.py`:
+
+```python
+class TestMDRecordsHead:
+    def test_run_md_writes_the_uma_task_into_the_record(self, tmp_path):
+        import json
+        from ase.build import bulk
+        from ase.calculators.emt import EMT
+        from mliprun.core.md import run_md
+
+        atoms = bulk("Cu", "fcc", a=3.6) * (2, 2, 2)
+        atoms.calc = EMT()
+        run_md(atoms, ensemble="nve", steps=2, log_interval=1,
+               traj_interval=1, output_dir=tmp_path, model_name="uma-s-1p2",
+               uma_task="oc25")
+
+        data = json.loads((tmp_path / "mliprun_run.json").read_text())
+        assert data["provenance"]["uma_task"] == "oc25"
+        assert data["provenance"]["mace_head"] is None
+        assert data["schema_version"] == 2
+```
+
+Add to `tests/test_core_optimize.py`:
+
+```python
+class TestOptimizeRecordsHead:
+    def test_run_optimization_writes_the_mace_head_into_the_record(self, tmp_path):
+        import json
+        from ase.build import bulk
+        from ase.calculators.emt import EMT
+        from mliprun.core.optimize import run_optimization
+
+        atoms = bulk("Cu", "fcc", a=3.7) * (2, 2, 2)
+        atoms.rattle(stdev=0.05, seed=42)
+        atoms.calc = EMT()
+        run_optimization(atoms, optimizer="bfgs", fmax=0.05, max_steps=20,
+                         output_dir=tmp_path, verbose=False,
+                         model_name="mace-mh-1", mace_head="omat_pbe")
+
+        data = json.loads((tmp_path / "mliprun_run.json").read_text())
+        assert data["provenance"]["mace_head"] == "omat_pbe"
+        assert data["provenance"]["uma_task"] is None
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `pytest tests/test_core_md.py::TestMDRecordsHead tests/test_core_optimize.py::TestOptimizeRecordsHead -v`
+Expected: FAIL — `TypeError: run_md() got an unexpected keyword argument 'uma_task'`.
+
+- [ ] **Step 3: Extend `run_optimization`**
+
+In `src/mliprun/core/optimize.py`, add two parameters immediately after `device_resolved: str = "auto",` in the signature:
+
+```python
+    uma_task: Optional[str] = None,
+    mace_head: Optional[str] = None,
+```
+
+Add to the docstring's parameter list, next to the existing `device_resolved` entry:
+
+```
+    uma_task : str, optional
+        UMA task actually used, recorded for provenance. Ignored for
+        non-UMA models.
+    mace_head : str, optional
+        MACE head actually used, recorded for provenance. Ignored for
+        non-MACE models.
+```
+
+Change the `collect_provenance` call to:
+
+```python
+        provenance=collect_provenance(
+            mlip_model=model_name,
+            device_requested=device_requested,
+            device_resolved=device_resolved,
+            uma_task=uma_task,
+            mace_head=mace_head,
+        ),
+```
+
+- [ ] **Step 4: Extend `run_md`**
+
+In `src/mliprun/core/md.py`, add the same two parameters immediately after `device_resolved: str = "auto",` in the `run_md` signature, the same two docstring entries next to the existing `device_resolved` entry, and change the `collect_provenance` call to:
+
+```python
+        provenance=collect_provenance(
+            mlip_model=model_name,
+            device_requested=device_requested,
+            device_resolved=device_resolved,
+            uma_task=uma_task,
+            mace_head=mace_head,
+        ),
+```
+
+- [ ] **Step 5: Wire both NEB call sites**
+
+In `src/mliprun/core/neb.py`, both `collect_provenance` calls (in the NEB stage at ~line 662 and the AutoNEB stage at ~line 815) become:
+
+```python
+            provenance=collect_provenance(
+                mlip_model=self.mlip,
+                device_requested=self.device,
+                device_resolved=resolve_device(self.device),
+                uma_task=self.uma_task,
+                mace_head=getattr(self, "mace_head", None),
+            ),
+```
+
+`getattr` rather than `self.mace_head`: `from_restart` sets the attribute on an instance built without it, and line 347 already uses the same defensive read.
+
+- [ ] **Step 6: Run the tests to verify they pass**
+
+Run: `pytest tests/test_core_md.py tests/test_core_optimize.py tests/test_core_neb.py -v`
+Expected: PASS.
+
+- [ ] **Step 7: Run the full unit suite**
+
+Run: `pytest -m "not uma and not mace and not sevenn"`
+Expected: PASS, goldens unmoved.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add src/mliprun/core/optimize.py src/mliprun/core/md.py src/mliprun/core/neb.py \
+        tests/test_core_md.py tests/test_core_optimize.py
+git commit -m "feat(core): pass the head/task through to the run record
+
+run_optimization and run_md take uma_task/mace_head and forward them to
+collect_provenance; both NEB stages read them off the CustomNEB instance,
+which already stores them.
+
+Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 3: Thread the head through the CLI
+
+**Files:**
+- Modify: `src/mliprun/cli/commands/optimize.py:124-140` (`optimize run`), `:286-302` (`optimize batch`)
+- Modify: `src/mliprun/cli/commands/md.py:215-238` (`md run`)
+- Test: `tests/test_cli_commands.py`
+
+**Interfaces:**
+- Consumes: `run_optimization(..., uma_task=..., mace_head=...)` and `run_md(..., uma_task=..., mace_head=...)` from Task 2.
+- Produces: no new API. The CLI commands already parse `uma_task` and `mace_head` into local variables of those names; this task only forwards them.
+
+Note: `neb` and `autoneb` CLI commands need no change — they already pass `uma_task` and `mace_head` into the `CustomNEB` constructor, and Task 2 reads them off the instance. Verify this in Step 3 before concluding the task.
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `tests/test_cli_commands.py`. This uses typer's in-process runner (the file's existing `_run_cli` shells out, which cannot observe call arguments) and stubs both the calculator setup and the engine, so no MLIP is required:
+
+```python
+from typer.testing import CliRunner
+
+from mliprun.cli.commands.md import app as md_app
+
+
+class TestCLIForwardsHead:
+    """The head is the one level-of-theory fact the record cannot infer,
+    so the CLI must hand it to the engine (CANON C1)."""
+
+    def test_md_run_forwards_the_uma_task(self, tmp_path, monkeypatch):
+        from ase.build import bulk
+        from ase.io import write
+
+        structure = tmp_path / "POSCAR"
+        write(str(structure), bulk("Cu", "fcc", a=3.6))
+
+        captured = {}
+        monkeypatch.setattr("mliprun.cli.commands.md.setup_calculator",
+                            lambda atoms, *a, **k: atoms)
+        monkeypatch.setattr("mliprun.cli.commands.md.validate_mlip",
+                            lambda *a, **k: None)
+        monkeypatch.setattr("mliprun.cli.commands.md.run_md",
+                            lambda **kwargs: captured.update(kwargs))
+
+        result = CliRunner().invoke(md_app, [
+            "run", "--structure", str(structure), "--mlip", "uma-s-1p2",
+            "--uma-task", "oc25", "--steps", "1",
+            "--output-dir", str(tmp_path),
+        ])
+
+        assert result.exit_code == 0, result.output
+        assert captured["uma_task"] == "oc25"
+        assert captured["mace_head"] is not None or "mace_head" in captured
+```
+
+Before running, confirm the exact option names with `md run --help` — if `--output-dir` is not an option on this command, drop it (the command defaults to writing next to the input structure, which is already `tmp_path`).
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `pytest tests/test_cli_commands.py::TestCLIForwardsHead -v`
+Expected: FAIL with `KeyError: 'uma_task'` — the CLI does not currently pass it.
+
+- [ ] **Step 3: Forward from `md run`**
+
+In `src/mliprun/cli/commands/md.py`, add to the `run_md(...)` call, next to the existing `device_resolved=_resolve_device(device),`:
+
+```python
+        uma_task=uma_task,
+        mace_head=mace_head,
+```
+
+- [ ] **Step 4: Forward from both optimize entry points**
+
+In `src/mliprun/cli/commands/optimize.py`, add the same two lines to the `run_optimization(...)` call in `run` (next to its `device_resolved=` argument) and to the one in `batch`.
+
+- [ ] **Step 5: Verify neb/autoneb need no change**
+
+Run: `grep -n "CustomNEB(" -A 15 src/mliprun/cli/commands/neb.py src/mliprun/cli/commands/autoneb.py | grep -n "uma_task\|mace_head"`
+Expected: both constructors already receive `uma_task=` and `mace_head=`. If either does not, add it — the constructor accepts both.
+
+- [ ] **Step 6: Run the tests to verify they pass**
+
+Run: `pytest tests/test_cli_commands.py -v`
+Expected: PASS.
+
+- [ ] **Step 7: Run the full unit suite**
+
+Run: `pytest -m "not uma and not mace and not sevenn"`
+Expected: PASS.
+
+- [ ] **Step 8: Update the run-record docstring pointer**
+
+In `src/mliprun/core/run_record.py`, change the design pointer line in the module docstring to name both documents:
+
+```
+Design: docs/superpowers/specs/2026-07-21-unified-run-record-design.md
+Amended: docs/superpowers/specs/2026-07-29-run-record-head-provenance-design.md
+```
+
+- [ ] **Step 9: Add a CHANGELOG entry**
+
+Under the unreleased/top section of `CHANGELOG.md`, matching the file's existing format:
+
+```markdown
+- Run record (`mliprun_run.json`) now records `uma_task` / `mace_head` in its
+  `provenance` block, so the record identifies the level of theory on its own.
+  Schema version 2.
+```
+
+- [ ] **Step 10: Commit**
+
+```bash
+git add src/mliprun/cli/commands/md.py src/mliprun/cli/commands/optimize.py \
+        src/mliprun/core/run_record.py tests/test_cli_commands.py CHANGELOG.md
+git commit -m "feat(cli): forward the head/task to the engines
+
+optimize run, optimize batch, and md run now pass their parsed
+--uma-task / --mace-head through to the core, so the run record names the
+head that actually ran. neb/autoneb already pass both into CustomNEB.
+
+Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>"
+```
+
+- [ ] **Step 11: Open the draft PR**
+
+```bash
+git push -u origin feat/run-record-head-provenance
+gh pr create --draft --title "feat: carry the MLIP head/task in the run record (schema v2)" \
+  --body "$(cat <<'EOF'
+`collect_provenance` took only the model tag, so `mliprun_run.json` named
+`uma-s-1p2` without the `oc25` task that actually ran. Under CANON C1 the head
+is its own explicit decision and under C3 heads must never be mixed within an
+energy formula, so the record could not serve as provenance for any energy
+entering a formula.
+
+- `uma_task` / `mace_head` as always-present nullable provenance fields, gated
+  on the model tag inside `collect_provenance` so a caller passing its parsed
+  option default cannot mislabel a run
+- `SCHEMA_VERSION` 1 -> 2, so a reader can tell an old record from a
+  genuinely-null field
+- both fields added to `_PROVENANCE_DIFF_FIELDS`, so a resume that switches
+  head is recorded in `stage_provenance`
+- threaded through `run_optimization`, `run_md`, both NEB stages, and the
+  optimize/md CLI commands
+
+No numerics touched; goldens unmoved.
+
+Design: `docs/superpowers/specs/2026-07-29-run-record-head-provenance-design.md`
+Driven by prov's MD capture work, which needs the head to record MD runs.
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+
+| Spec requirement | Task |
+|---|---|
+| `collect_provenance` gains `uma_task` / `mace_head` | 1 |
+| Always present, null when not applicable | 1 |
+| Gated on model family | 1 |
+| `SCHEMA_VERSION` 1 → 2 | 1 |
+| `_PROVENANCE_DIFF_FIELDS` extended | 1 |
+| `run_optimization` threading | 2 |
+| `run_md` threading | 2 |
+| NEB / AutoNEB call sites | 2 |
+| CLI call sites | 3 |
+| Golden safety (no regeneration) | Global Constraints + Steps 1.7, 2.7, 3.7 |
+| Tests written first | every task, Steps 1-2 |
+| Docstring pointer updated | 3.8 |
+| Out of scope: no backfill of existing records | not implemented anywhere — correct |
+
+**Placeholder scan:** none. Two steps ask the implementer to verify something before proceeding (3.1's option-name check, 3.5's neb/autoneb check) — both carry the exact command to run and the expected result, and both have a stated action if the expectation fails.
+
+**Type consistency:** `uma_task` and `mace_head` are `Optional[str]` defaulting to `None` at every layer — `collect_provenance`, `run_optimization`, `run_md`, and the CLI locals of the same names. `SCHEMA_VERSION` is `int` 2 in the constant, the assertion, and the written record.

--- a/docs/superpowers/plans/2026-07-29-run-record-head-provenance.md
+++ b/docs/superpowers/plans/2026-07-29-run-record-head-provenance.md
@@ -406,7 +406,10 @@ class TestCLIForwardsHead:
 
         assert result.exit_code == 0, result.output
         assert captured["uma_task"] == "oc25"
-        assert captured["mace_head"] is not None or "mace_head" in captured
+        # The CLI forwards its parsed --mace-head default verbatim; gating a
+        # UMA run's mace_head to None is collect_provenance's job, not the
+        # CLI's, and is covered by Task 1.
+        assert captured["mace_head"] == "omat_pbe"
 ```
 
 Before running, confirm the exact option names with `md run --help` — if `--output-dir` is not an option on this command, drop it (the command defaults to writing next to the input structure, which is already `tmp_path`).

--- a/docs/superpowers/specs/2026-07-29-run-record-head-provenance-design.md
+++ b/docs/superpowers/specs/2026-07-29-run-record-head-provenance-design.md
@@ -1,0 +1,96 @@
+# Run record: carry the MLIP head/task (schema v2)
+
+**Date:** 2026-07-29
+**Amends:** `2026-07-21-unified-run-record-design.md`
+**Driven by:** `~/github/work/prov/docs/superpowers/specs/2026-07-29-md-provenance-capture-design.md` (Part A)
+**Status:** approved design, not yet implemented
+
+## Problem
+
+`collect_provenance` takes only the model tag. A real MD record on disk reads:
+
+```json
+"mlip_model": "uma-s-1p2",
+"device_requested": "cuda",
+```
+
+with no mention of the UMA task the run actually used (`oc25`, recoverable only
+from `md_params.txt`). The same gap applies to `mace_head`, and to optimize and
+NEB records as well as MD.
+
+`mliprun_run.json` presents itself as the canonical run record, but under CANON
+C1 the head/task is its own explicit decision, and under C3 heads must never be
+mixed within a γ, adsorption-energy, or ΔE formula. A record naming only
+`uma-s-1p2` cannot answer "which head produced this number", so it cannot serve
+as provenance for any energy that enters a formula.
+
+## Change
+
+Two keyword-only parameters on `collect_provenance`, both defaulting to `None`,
+emitted as keys that are **always present and null when not applicable**:
+
+```python
+def collect_provenance(*, mlip_model, device_requested, device_resolved,
+                       uma_task=None, mace_head=None) -> dict:
+    ...
+    "uma_task": uma_task,     # non-null only for uma-* models
+    "mace_head": mace_head,   # non-null only for mace-mh-* models
+```
+
+Two fields rather than one normalized `mlip_head`: it preserves the upstream
+vocabulary (UMA calls it a task, MACE calls it a head) and matches the keys the
+`prov` ledger's `level_of_theory` already uses, so neither side needs a mapping
+layer. Always-present-with-null follows the existing house style — `mlip_package`
+is always present with null fields rather than omitted.
+
+Both parameters keep `None` defaults so existing library callers and test doubles
+continue to work unchanged.
+
+## Schema version
+
+`SCHEMA_VERSION` 1 → 2.
+
+The bump is load-bearing. Without it a reader cannot distinguish "no `uma_task`
+key because the record predates this change" from "`uma_task` is null because
+this was a MACE run". `prov` uses exactly that distinction to decide whether to
+fall back to parsing `md_params.txt` for the head.
+
+## `_PROVENANCE_DIFF_FIELDS`
+
+Add `"uma_task"` and `"mace_head"`.
+
+That tuple governs which provenance changes an appended stage records in
+`stage_provenance`. A resume that switched head is precisely what CANON C3
+forbids, so it is the last thing that should go unrecorded.
+
+## Call sites to thread
+
+- `core/optimize.py::run_optimization` — add `uma_task=None, mace_head=None`.
+- `core/md.py::run_md` — same.
+- `core/neb.py` — `CustomNEB` already stores `self.uma_task` / `self.mace_head`;
+  pass them at its `collect_provenance` call site.
+- Any other core call site of `collect_provenance`, autoneb path included.
+- CLI commands `optimize.py`, `md.py`, `neb.py`, `autoneb.py` pass the values
+  they already parse.
+
+## Golden safety
+
+The characterization goldens assert numerics read from `opt_convergence.csv`,
+`md_energy.csv`, and final structure files. None reads `mliprun_run.json`, so
+adding provenance fields cannot move a golden. **Do not regenerate goldens.**
+
+## Tests (written first)
+
+- `collect_provenance` returns both keys, null by default.
+- UMA model + task recorded; MACE model + head recorded.
+- `SCHEMA_VERSION == 2`, and a written record carries it.
+- End-to-end: `run_md(..., uma_task="oc25")` writes
+  `provenance.uma_task == "oc25"`.
+- A resumed stage that changes head records it in `stage_provenance`; a
+  same-head resume omits `stage_provenance` entirely.
+
+## Out of scope
+
+Backfilling the head into records already on disk. The 7 existing MD records and
+every optimize record stay at schema 1; `prov` recovers their head from
+`md_params.txt` / `opt_params.txt` instead.

--- a/src/mliprun/cli/commands/md.py
+++ b/src/mliprun/cli/commands/md.py
@@ -235,6 +235,8 @@ def run(
         run_context=run_context,
         device_requested=device,
         device_resolved=_resolve_device(device),
+        uma_task=uma_task,
+        mace_head=mace_head,
     )
 
     # List output files

--- a/src/mliprun/cli/commands/optimize.py
+++ b/src/mliprun/cli/commands/optimize.py
@@ -136,6 +136,8 @@ def run(
         run_context=run_context,
         device_requested=device,
         device_resolved=_resolve_device(device),
+        uma_task=uma_task,
+        mace_head=mace_head,
     )
 
     # Save parameters
@@ -298,6 +300,8 @@ def batch(
                 run_context=run_context,
                 device_requested=device,
                 device_resolved=_resolve_device(device),
+                uma_task=uma_task,
+                mace_head=mace_head,
             )
             walltime = time.perf_counter() - t0
             energy = atoms.get_potential_energy()

--- a/src/mliprun/core/md.py
+++ b/src/mliprun/core/md.py
@@ -236,6 +236,8 @@ def run_md(
     run_context: Optional[RunContext] = None,
     device_requested: str = "auto",
     device_resolved: str = "auto",
+    uma_task: Optional[str] = None,
+    mace_head: Optional[str] = None,
 ) -> None:
     """Run molecular dynamics simulation.
 
@@ -273,6 +275,12 @@ def run_md(
         The device as asked for (e.g. ``'auto'``), recorded for provenance.
     device_resolved : str
         The device actually used (e.g. ``'cuda'``).
+    uma_task : str, optional
+        UMA task actually used, recorded for provenance. Ignored for
+        non-UMA models.
+    mace_head : str, optional
+        MACE head actually used, recorded for provenance. Ignored for
+        non-MACE models.
 
     (Other parameters as in :func:`setup_dynamics`.)
     """
@@ -324,6 +332,8 @@ def run_md(
             mlip_model=model_name,
             device_requested=device_requested,
             device_resolved=device_resolved,
+            uma_task=uma_task,
+            mace_head=mace_head,
         ),
         run_context=run_context,
         append=resume,

--- a/src/mliprun/core/neb.py
+++ b/src/mliprun/core/neb.py
@@ -664,6 +664,11 @@ class CustomNEB:
                 device_requested=self.device,
                 device_resolved=resolve_device(self.device),
                 uma_task=self.uma_task,
+                # Default None, unlike setup_calculator's "omat_pbe": the
+                # calculator needs *a* usable head to run at all, but the
+                # record must never invent one it cannot verify was used
+                # (CANON C1 -- the head is an explicit decision, never
+                # inferred). An unset attribute is recorded as unknown.
                 mace_head=getattr(self, "mace_head", None),
             ),
             run_context=run_context,
@@ -819,6 +824,8 @@ class CustomNEB:
                 device_requested=self.device,
                 device_resolved=resolve_device(self.device),
                 uma_task=self.uma_task,
+                # Default None, unlike setup_calculator's "omat_pbe" -- see
+                # the same call in run_neb: a record must not invent a head.
                 mace_head=getattr(self, "mace_head", None),
             ),
             run_context=run_context,

--- a/src/mliprun/core/neb.py
+++ b/src/mliprun/core/neb.py
@@ -663,6 +663,8 @@ class CustomNEB:
                 mlip_model=self.mlip,
                 device_requested=self.device,
                 device_resolved=resolve_device(self.device),
+                uma_task=self.uma_task,
+                mace_head=getattr(self, "mace_head", None),
             ),
             run_context=run_context,
             # k, climb, max_steps, the optimizer, and fmax are arguments of
@@ -816,6 +818,8 @@ class CustomNEB:
                 mlip_model=self.mlip,
                 device_requested=self.device,
                 device_resolved=resolve_device(self.device),
+                uma_task=self.uma_task,
+                mace_head=getattr(self, "mace_head", None),
             ),
             run_context=run_context,
         )

--- a/src/mliprun/core/optimize.py
+++ b/src/mliprun/core/optimize.py
@@ -53,6 +53,8 @@ def run_optimization(
     run_context: Optional[RunContext] = None,
     device_requested: str = "auto",
     device_resolved: str = "auto",
+    uma_task: Optional[str] = None,
+    mace_head: Optional[str] = None,
 ) -> bool:
     """Run geometry optimization on an ASE Atoms object.
 
@@ -97,6 +99,12 @@ def run_optimization(
         The device as asked for (e.g. ``'auto'``), recorded for provenance.
     device_resolved : str
         The device actually used (e.g. ``'cuda'``).
+    uma_task : str, optional
+        UMA task actually used, recorded for provenance. Ignored for
+        non-UMA models.
+    mace_head : str, optional
+        MACE head actually used, recorded for provenance. Ignored for
+        non-MACE models.
 
     Returns
     -------
@@ -153,6 +161,8 @@ def run_optimization(
             mlip_model=model_name,
             device_requested=device_requested,
             device_resolved=device_resolved,
+            uma_task=uma_task,
+            mace_head=mace_head,
         ),
         run_context=run_context,
     )

--- a/src/mliprun/core/run_record.py
+++ b/src/mliprun/core/run_record.py
@@ -29,7 +29,7 @@ from typing import Any, Optional
 logger = logging.getLogger(__name__)
 
 RECORD_FILENAME = "mliprun_run.json"
-SCHEMA_VERSION = 1
+SCHEMA_VERSION = 2
 
 #: Model-tag prefix -> installed distribution name. Longest prefix wins, so
 #: ``mace-mh-1`` resolves before the bare ``mace`` entry.
@@ -49,7 +49,8 @@ VALID_PARAM_SOURCES = frozenset({"user", "default", "env", "prompt", "unspecifie
 #: Provenance fields compared between the run's origin and an appended
 #: stage. Only these four are meaningful to call out as "what changed" --
 #: see I2 in .superpowers/sdd/task-1-fixes.md.
-_PROVENANCE_DIFF_FIELDS = ("mliprun_version", "hostname", "device_resolved", "mlip_model")
+_PROVENANCE_DIFF_FIELDS = ("mliprun_version", "hostname", "device_resolved",
+                           "mlip_model", "uma_task", "mace_head")
 
 
 def _now_iso() -> str:
@@ -157,7 +158,8 @@ def _mlip_package(mlip_model: Any) -> dict:
 
 
 def collect_provenance(*, mlip_model: Any, device_requested: str,
-                        device_resolved: str) -> dict:
+                        device_resolved: str, uma_task: Optional[str] = None,
+                        mace_head: Optional[str] = None) -> dict:
     """Gather environment and version facts for the record.
 
     ``device_requested`` and ``device_resolved`` are kept apart because
@@ -168,6 +170,13 @@ def collect_provenance(*, mlip_model: Any, device_requested: str,
     ``None`` fields is far better than no record, and this function must
     never raise -- ``socket.gethostname()`` genuinely fails on some
     HPC/container setups.
+
+    ``uma_task`` and ``mace_head`` are gated on the model tag rather than
+    trusted from the caller: CLIs pass whatever their ``--uma-task`` /
+    ``--mace-head`` options resolved to, defaults included, so a MACE run
+    would otherwise be recorded as carrying a UMA task it never used.
+    CANON C1 makes the head its own explicit decision and C3 forbids mixing
+    heads within an energy formula, so a wrong head is worse than none.
     """
     try:
         mliprun_version = version("mliprun")
@@ -189,11 +198,14 @@ def collect_provenance(*, mlip_model: Any, device_requested: str,
         hostname = socket.gethostname()
     except Exception:  # noqa: BLE001 -- fails on some HPC/container setups
         hostname = None
+    tag = mlip_model if isinstance(mlip_model, str) else ""
     return {
         "mliprun_version": mliprun_version,
         "ase_version": ase_version,
         "mlip_package": mlip_package,
         "mlip_model": mlip_model,
+        "uma_task": uma_task if tag.startswith("uma-") else None,
+        "mace_head": mace_head if tag.startswith("mace-mh-") else None,
         "device_requested": device_requested,
         "device_resolved": device_resolved,
         "python_version": python_version,

--- a/src/mliprun/core/run_record.py
+++ b/src/mliprun/core/run_record.py
@@ -53,6 +53,10 @@ VALID_PARAM_SOURCES = frozenset({"user", "default", "env", "prompt", "unspecifie
 _PROVENANCE_DIFF_FIELDS = ("mliprun_version", "hostname", "device_resolved",
                            "mlip_model", "uma_task", "mace_head")
 
+#: Stage key for diff fields the incoming provenance carries but the stored
+#: top-level provenance has no slot for at all -- see `_split_provenance`.
+NEW_FIELDS_KEY = "stage_provenance_new_fields"
+
 
 def _now_iso() -> str:
     """Timezone-aware local timestamp, ISO 8601."""
@@ -172,6 +176,14 @@ def collect_provenance(*, mlip_model: Any, device_requested: str,
     never raise -- ``socket.gethostname()`` genuinely fails on some
     HPC/container setups.
 
+    That "must never raise" is a load-bearing invariant, not a courtesy:
+    callers evaluate ``collect_provenance(...)`` as an argument expression,
+    so it runs at the call site, *outside* :meth:`RunRecord.begin`'s
+    ``try``. The module guarantee that a record failure never kills a run
+    rests on this function being total; ``begin``'s handler cannot catch
+    what is raised before ``begin`` is entered. Keep every new fallible
+    call inside its own guard.
+
     ``uma_task`` and ``mace_head`` are gated on the model tag rather than
     trusted from the caller: CLIs pass whatever their ``--uma-task`` /
     ``--mace-head`` options resolved to, defaults included, so a MACE run
@@ -270,6 +282,39 @@ def _tag(parameters: dict, sources: Optional[dict]) -> dict:
     }
 
 
+def _split_provenance(prov_in: dict, top_prov: dict) -> tuple[dict, dict]:
+    """Sort an appended stage's provenance into "changed" and "new".
+
+    Returns ``(changed, new)``. ``changed`` holds the fields whose value
+    differs from the run's origin -- a genuine environment switch, the
+    ``stage_provenance`` contract. ``new`` holds the fields the stored
+    provenance has **no key for at all**, which is a different fact and must
+    not be reported as a change.
+
+    The distinction exists because a schema-1 record predates ``uma_task`` /
+    ``mace_head``. Comparing with ``dict.get`` on both sides makes "the key
+    was never written" look identical to "the key is null", so resuming a
+    legacy UMA run with the *same* head would claim the head had switched --
+    a CANON C3 false positive in the very artifact that answers C3 questions.
+    A missing key means stage 0's value is unknown, not that it was
+    different; the params text file next to the record is the only remaining
+    evidence of what stage 0 actually ran.
+
+    Fields absent from ``prov_in`` are in neither dict: this stage has
+    nothing to say about them.
+    """
+    changed: dict = {}
+    new: dict = {}
+    for key in _PROVENANCE_DIFF_FIELDS:
+        if key not in prov_in:
+            continue
+        if key not in top_prov:
+            new[key] = prov_in[key]
+        elif prov_in[key] != top_prov[key]:
+            changed[key] = prov_in[key]
+    return changed, new
+
+
 class RunRecord:
     """A record being written. Obtain one from :meth:`begin`."""
 
@@ -325,15 +370,18 @@ class RunRecord:
                 # instead the stage records only what differs from it, so a
                 # reader can see what changed about the environment between
                 # stages without losing the original context.
+                # I4 (human ruling): a field the stored record has no key
+                # for is reported under NEW_FIELDS_KEY, never as a change.
+                # `schema_version` is deliberately left as stage 0 wrote it:
+                # rewriting it would assert this code's schema over a stage
+                # whose provenance this code never collected.
                 top_prov = payload.get("provenance") or {}
-                prov_in = provenance or {}
-                stage_delta = {
-                    key: prov_in.get(key)
-                    for key in _PROVENANCE_DIFF_FIELDS
-                    if prov_in.get(key) != top_prov.get(key)
-                }
+                stage_delta, new_fields = _split_provenance(
+                    provenance or {}, top_prov)
                 if stage_delta:
                     stage["stage_provenance"] = stage_delta
+                if new_fields:
+                    stage[NEW_FIELDS_KEY] = new_fields
             else:
                 prov = dict(provenance)
                 prov["started_at"] = _now_iso()

--- a/src/mliprun/core/run_record.py
+++ b/src/mliprun/core/run_record.py
@@ -5,6 +5,7 @@ every caller gets one -- CLI commands and direct library callers alike. This
 module is the only place that knows the file format.
 
 Design: docs/superpowers/specs/2026-07-21-unified-run-record-design.md
+Amended: docs/superpowers/specs/2026-07-29-run-record-head-provenance-design.md
 
 The governing rule is that a record failure must never kill a run: every
 public entry point swallows its own exceptions and logs a warning. A six-hour

--- a/src/mliprun/core/run_record.py
+++ b/src/mliprun/core/run_record.py
@@ -47,7 +47,7 @@ _MLIP_PACKAGES = (
 VALID_PARAM_SOURCES = frozenset({"user", "default", "env", "prompt", "unspecified"})
 
 #: Provenance fields compared between the run's origin and an appended
-#: stage. Only these four are meaningful to call out as "what changed" --
+#: stage. Only these fields are meaningful to call out as "what changed" --
 #: see I2 in .superpowers/sdd/task-1-fixes.md.
 _PROVENANCE_DIFF_FIELDS = ("mliprun_version", "hostname", "device_resolved",
                            "mlip_model", "uma_task", "mace_head")

--- a/tests/test_cli_commands.py
+++ b/tests/test_cli_commands.py
@@ -2,6 +2,10 @@
 import subprocess
 import pytest
 
+from typer.testing import CliRunner
+
+from mliprun.cli.commands.md import app as md_app
+
 
 def _run_cli(cmd):
     """Run a CLI command and return the result."""
@@ -42,3 +46,40 @@ class TestMissingArgs:
         result = _run_cli(["neb", "run"])
         # Should fail: neither --initial/--final nor --restart provided
         assert result.returncode != 0
+
+
+class TestCLIForwardsHead:
+    """The head is the one level-of-theory fact the record cannot infer,
+    so the CLI must hand it to the engine (CANON C1)."""
+
+    def test_md_run_forwards_the_uma_task(self, tmp_path, monkeypatch):
+        from ase.build import bulk
+        from ase.io import write
+
+        structure = tmp_path / "POSCAR"
+        write(str(structure), bulk("Cu", "fcc", a=3.6))
+
+        captured = {}
+        monkeypatch.setattr("mliprun.cli.commands.md.setup_calculator",
+                            lambda atoms, *a, **k: atoms)
+        monkeypatch.setattr("mliprun.cli.commands.md.validate_mlip",
+                            lambda *a, **k: None)
+        monkeypatch.setattr("mliprun.cli.commands.md.run_md",
+                            lambda **kwargs: captured.update(kwargs))
+
+        # md_app registers a single command, so typer collapses it to a
+        # top-level CLI: there is no "run" subcommand to pass (confirmed via
+        # `md --help` / `md run --help` -- the latter only "works" because
+        # --help is resolved eagerly, before the extra "run" argument is
+        # validated).
+        result = CliRunner().invoke(md_app, [
+            "--structure", str(structure), "--mlip", "uma-s-1p2",
+            "--uma-task", "oc25", "--steps", "1",
+        ])
+
+        assert result.exit_code == 0, result.output
+        assert captured["uma_task"] == "oc25"
+        # The CLI forwards its parsed --mace-head default verbatim; gating a
+        # UMA run's mace_head to None is collect_provenance's job, not the
+        # CLI's, and is covered by Task 1.
+        assert captured["mace_head"] == "omat_pbe"

--- a/tests/test_core_md.py
+++ b/tests/test_core_md.py
@@ -130,3 +130,22 @@ class TestRunMd:
                 atoms, ensemble="nvt", steps=5, log_interval=1, traj_interval=1,
                 output_dir=tmp_workdir, resume=True,
             )
+
+
+class TestMDRecordsHead:
+    def test_run_md_writes_the_uma_task_into_the_record(self, tmp_path):
+        import json
+        from ase.build import bulk
+        from ase.calculators.emt import EMT
+        from mliprun.core.md import run_md
+
+        atoms = bulk("Cu", "fcc", a=3.6) * (2, 2, 2)
+        atoms.calc = EMT()
+        run_md(atoms, ensemble="nve", steps=2, log_interval=1,
+               traj_interval=1, output_dir=tmp_path, model_name="uma-s-1p2",
+               uma_task="oc25")
+
+        data = json.loads((tmp_path / "mliprun_run.json").read_text())
+        assert data["provenance"]["uma_task"] == "oc25"
+        assert data["provenance"]["mace_head"] is None
+        assert data["schema_version"] == 2

--- a/tests/test_core_optimize.py
+++ b/tests/test_core_optimize.py
@@ -78,3 +78,22 @@ class TestOptimizerSelection:
             output_dir=tmp_workdir, verbose=False,
         )
         assert converged is True or converged is False or isinstance(converged, (bool, np.bool_))
+
+
+class TestOptimizeRecordsHead:
+    def test_run_optimization_writes_the_mace_head_into_the_record(self, tmp_path):
+        import json
+        from ase.build import bulk
+        from ase.calculators.emt import EMT
+        from mliprun.core.optimize import run_optimization
+
+        atoms = bulk("Cu", "fcc", a=3.7) * (2, 2, 2)
+        atoms.rattle(stdev=0.05, seed=42)
+        atoms.calc = EMT()
+        run_optimization(atoms, optimizer="bfgs", fmax=0.05, max_steps=20,
+                         output_dir=tmp_path, verbose=False,
+                         model_name="mace-mh-1", mace_head="omat_pbe")
+
+        data = json.loads((tmp_path / "mliprun_run.json").read_text())
+        assert data["provenance"]["mace_head"] == "omat_pbe"
+        assert data["provenance"]["uma_task"] is None

--- a/tests/test_run_record.py
+++ b/tests/test_run_record.py
@@ -8,6 +8,7 @@ import numpy as np
 import pytest
 
 from mliprun.core.run_record import (
+    NEW_FIELDS_KEY,
     RECORD_FILENAME,
     SCHEMA_VERSION,
     BatchInfo,
@@ -413,6 +414,8 @@ class TestHeadInStageProvenance:
         data = _read(tmp_path)
         assert data["stages"][1]["stage_provenance"] == {"uma_task": "oc25"}
         assert data["provenance"]["uma_task"] == "omat"
+        # Present-and-different is a real change, not a new field.
+        assert NEW_FIELDS_KEY not in data["stages"][1]
 
     def test_append_with_same_head_writes_no_stage_provenance(self, tmp_path):
         base = {"mliprun_version": "0.4.0", "hostname": "node-a",
@@ -422,4 +425,120 @@ class TestHeadInStageProvenance:
         rec.complete(status="converged")
         rec2 = _begin(tmp_path, provenance=dict(base), append=True)
         rec2.complete(status="converged")
-        assert "stage_provenance" not in _read(tmp_path)["stages"][1]
+        stage = _read(tmp_path)["stages"][1]
+        assert "stage_provenance" not in stage
+        # Present-and-same: neither key. A null `mace_head` on both sides is
+        # "no MACE head applies", not a fact worth flagging.
+        assert NEW_FIELDS_KEY not in stage
+
+
+#: A record as schema 1 wrote it: no `uma_task` / `mace_head` keys anywhere.
+_SCHEMA_1_PROVENANCE = {
+    "mliprun_version": "0.4.0",
+    "ase_version": "3.23.0",
+    "mlip_package": {"name": "fairchem-core", "version": "2.0.0"},
+    "mlip_model": "uma-s-1p2",
+    "device_requested": "cuda",
+    "device_resolved": "cuda",
+    "python_version": "3.11.9",
+    "hostname": "node-a",
+    "started_at": "2026-07-01T09:00:00+08:00",
+    "finished_at": "2026-07-01T11:00:00+08:00",
+    "walltime_s": 7200.0,
+}
+
+
+def _write_schema_1_record(tmp_path):
+    """Drop a genuine schema-1 record on disk for an append to resume."""
+    (tmp_path / RECORD_FILENAME).write_text(json.dumps({
+        "schema_version": 1,
+        "command": "neb",
+        "status": "converged",
+        "run": {"mode": "one-off", "batch": None},
+        "inputs": {"n_images": 5, "n_atoms": 32},
+        "parameters": {},
+        "provenance": dict(_SCHEMA_1_PROVENANCE),
+        "stages": [{
+            "index": 0, "kind": "neb", "status": "converged",
+            "started_at": "2026-07-01T09:00:00+08:00",
+            "walltime_s": 7200.0, "steps": 120, "results": {},
+        }],
+    }, indent=2))
+
+
+def _schema_2_provenance(**overrides):
+    """The same environment, described by schema-2 collect_provenance()."""
+    prov = dict(_SCHEMA_1_PROVENANCE, uma_task="omat", mace_head=None)
+    prov.update(overrides)
+    return prov
+
+
+class TestNewFieldsMarker:
+    """I4 (human ruling): a diff field the stored record has no key for is
+    reported as *new*, never as *changed*.
+
+    A schema-1 record predates `uma_task`/`mace_head`, so comparing with
+    `.get()` on both sides made "never written" indistinguishable from
+    "null" -- and a same-head resume of a legacy UMA run claimed the head
+    had switched. That is a CANON C3 false positive in the artifact whose
+    whole job is answering C3 questions.
+    """
+
+    def test_same_head_resume_of_a_legacy_record_claims_no_change(self, tmp_path):
+        _write_schema_1_record(tmp_path)
+        rec = _begin(tmp_path, command="neb", stage_kind="neb-restart",
+                     append=True, provenance=_schema_2_provenance())
+        rec.complete(status="converged")
+
+        stage = _read(tmp_path)["stages"][1]
+        # The head did NOT change, so nothing may go to stage_provenance.
+        assert "stage_provenance" not in stage
+        assert stage[NEW_FIELDS_KEY] == {"uma_task": "omat", "mace_head": None}
+
+    def test_marker_carries_this_stage_s_head_not_a_guess_at_stage_0(self, tmp_path):
+        """The reader must see what ran *now*; stage 0 stays unknown."""
+        _write_schema_1_record(tmp_path)
+        rec = _begin(tmp_path, command="neb", stage_kind="neb-restart",
+                     append=True,
+                     provenance=_schema_2_provenance(uma_task="oc25"))
+        rec.complete(status="converged")
+
+        data = _read(tmp_path)
+        assert data["stages"][1][NEW_FIELDS_KEY]["uma_task"] == "oc25"
+        # The origin provenance is never back-filled: stage 0's head is not
+        # knowable from this record, and inventing it would be worse.
+        assert "uma_task" not in data["provenance"]
+
+    def test_legacy_append_leaves_schema_version_at_one(self, tmp_path):
+        """The record becomes a hybrid, and says so honestly. Rewriting it
+        to 2 would assert stage 0 carried fields it never did."""
+        _write_schema_1_record(tmp_path)
+        rec = _begin(tmp_path, command="neb", stage_kind="neb-restart",
+                     append=True, provenance=_schema_2_provenance())
+        rec.complete(status="converged")
+        assert _read(tmp_path)["schema_version"] == 1
+
+    def test_a_real_change_still_reaches_stage_provenance(self, tmp_path):
+        """Both keys can appear at once: the hostname genuinely moved, and
+        the head fields are merely new."""
+        _write_schema_1_record(tmp_path)
+        rec = _begin(tmp_path, command="neb", stage_kind="neb-restart",
+                     append=True,
+                     provenance=_schema_2_provenance(hostname="node-b"))
+        rec.complete(status="converged")
+
+        stage = _read(tmp_path)["stages"][1]
+        assert stage["stage_provenance"] == {"hostname": "node-b"}
+        assert stage[NEW_FIELDS_KEY] == {"uma_task": "omat", "mace_head": None}
+
+    def test_field_absent_from_the_incoming_provenance_is_reported_nowhere(self, tmp_path):
+        """A minimal caller that omits the head fields entirely has nothing
+        to say about them -- neither key may appear."""
+        _write_schema_1_record(tmp_path)
+        rec = _begin(tmp_path, command="neb", stage_kind="neb-restart",
+                     append=True, provenance=dict(_SCHEMA_1_PROVENANCE))
+        rec.complete(status="converged")
+
+        stage = _read(tmp_path)["stages"][1]
+        assert "stage_provenance" not in stage
+        assert NEW_FIELDS_KEY not in stage

--- a/tests/test_run_record.py
+++ b/tests/test_run_record.py
@@ -344,3 +344,82 @@ class TestReviewFixes:
         backups = list(tmp_path.glob(f"{RECORD_FILENAME}.corrupt-*"))
         assert len(backups) == 1
         assert backups[0].read_text() == "[]"
+
+
+class TestHeadProvenance:
+    """CANON C1/C3: the head/task is its own decision and must never be
+    inferred. A record naming only the model tag cannot identify the level
+    of theory."""
+
+    def test_head_fields_default_to_none(self):
+        prov = collect_provenance(mlip_model="chgnet", device_requested="cpu",
+                                  device_resolved="cpu")
+        assert prov["uma_task"] is None
+        assert prov["mace_head"] is None
+
+    def test_records_uma_task_for_uma_model(self):
+        prov = collect_provenance(mlip_model="uma-s-1p2", device_requested="cuda",
+                                  device_resolved="cuda", uma_task="oc25")
+        assert prov["uma_task"] == "oc25"
+        assert prov["mace_head"] is None
+
+    def test_records_mace_head_for_mace_model(self):
+        prov = collect_provenance(mlip_model="mace-mh-1", device_requested="cpu",
+                                  device_resolved="cpu", mace_head="omat_pbe")
+        assert prov["mace_head"] == "omat_pbe"
+        assert prov["uma_task"] is None
+
+    def test_drops_head_that_does_not_match_the_model_family(self):
+        """A CLI passes its parsed --uma-task unconditionally, defaults
+        included. A MACE run must not inherit a UMA task it never used."""
+        prov = collect_provenance(mlip_model="mace-mh-1", device_requested="cpu",
+                                  device_resolved="cpu", uma_task="omat",
+                                  mace_head="omat_pbe")
+        assert prov["uma_task"] is None
+        assert prov["mace_head"] == "omat_pbe"
+
+    def test_tolerates_non_string_model(self):
+        prov = collect_provenance(mlip_model=None, device_requested="cpu",
+                                  device_resolved="cpu", uma_task="omat")
+        assert prov["uma_task"] is None
+        assert prov["mace_head"] is None
+
+
+class TestSchemaVersion:
+    def test_schema_version_is_two(self):
+        """Bumped so a reader can tell 'no uma_task key because the record
+        predates the field' from 'uma_task is null because it was MACE'."""
+        assert SCHEMA_VERSION == 2
+
+    def test_written_record_carries_the_new_version(self, tmp_path):
+        _begin(tmp_path)
+        assert _read(tmp_path)["schema_version"] == 2
+
+
+class TestHeadInStageProvenance:
+    def test_append_records_a_switched_head(self, tmp_path):
+        """C3 forbids mixing heads within an energy formula, so a resume
+        that switches head is exactly what must not go unrecorded."""
+        base = {"mliprun_version": "0.4.0", "hostname": "node-a",
+                "device_resolved": "cuda", "mlip_model": "uma-s-1p2",
+                "uma_task": "omat", "mace_head": None}
+        rec = _begin(tmp_path, provenance=dict(base))
+        rec.complete(status="converged")
+
+        rec2 = _begin(tmp_path, provenance=dict(base, uma_task="oc25"),
+                      append=True)
+        rec2.complete(status="converged")
+
+        data = _read(tmp_path)
+        assert data["stages"][1]["stage_provenance"] == {"uma_task": "oc25"}
+        assert data["provenance"]["uma_task"] == "omat"
+
+    def test_append_with_same_head_writes_no_stage_provenance(self, tmp_path):
+        base = {"mliprun_version": "0.4.0", "hostname": "node-a",
+                "device_resolved": "cuda", "mlip_model": "uma-s-1p2",
+                "uma_task": "omat", "mace_head": None}
+        rec = _begin(tmp_path, provenance=dict(base))
+        rec.complete(status="converged")
+        rec2 = _begin(tmp_path, provenance=dict(base), append=True)
+        rec2.complete(status="converged")
+        assert "stage_provenance" not in _read(tmp_path)["stages"][1]

--- a/tests/test_run_record_integration.py
+++ b/tests/test_run_record_integration.py
@@ -30,6 +30,27 @@ def _record(d):
     return json.loads((d / RECORD_FILENAME).read_text())
 
 
+#: One case per MLIP family, for the head/task forwarding tests:
+#: (model tag, provenance/keyword name, a **non-default** value, the sibling
+#: key that must stay null because it belongs to the other family).
+#: Every value here is deliberately not the CLI/engine default -- see
+#: `test_run_forwards_the_head_to_the_record`.
+#:
+#: The ids must not be the bare words `uma`/`mace`: a parametrize id becomes
+#: a pytest keyword, and conftest's `pytest_collection_modifyitems` skips
+#: anything keyworded `uma`/`mace` when that package is absent -- which would
+#: silently disable every case here. Model tags collide with nothing.
+_HEAD_CASES = [
+    pytest.param("uma-s-1p2", "uma_task", "oc25", "mace_head", id="uma-s-1p2"),
+    pytest.param("mace-mh-1", "mace_head", "omol", "uma_task", id="mace-mh-1"),
+]
+
+
+def _flag(head: str) -> str:
+    """`uma_task` -> `--uma-task`."""
+    return "--" + head.replace("_", "-")
+
+
 class TestOptimizeRecord:
     def test_library_caller_gets_a_complete_record(self, tmp_path):
         """A caller that bypasses the CLI still gets a record -- the defect
@@ -156,6 +177,48 @@ class TestOptimizeCliRecord:
         assert rows[0] == ["subdir", "status", "converged", "steps",
                             "energy_eV", "walltime_s", "detail"]
         assert any(row[0] == "a" for row in rows[1:])
+
+    @pytest.mark.parametrize("mlip,head,value,other", _HEAD_CASES)
+    def test_run_forwards_the_head_to_the_record(self, tmp_path, emt_patched,
+                                                  mlip, head, value, other):
+        """`optimize run` must hand its parsed head/task to the engine.
+
+        A **non-default** value is required: with the default, a value the
+        CLI parsed and one the engine defaulted to are indistinguishable, so
+        the assertion would still pass with the kwarg deleted.
+        """
+        struct = tmp_path / "init.vasp"
+        write(str(struct), bulk("Cu", "fcc", a=3.7), format="vasp")
+
+        result = runner.invoke(optimize_app, [
+            "run", "--structure", str(struct), "--mlip", mlip,
+            _flag(head), value, "--fmax", "0.5", "--max-steps", "5",
+        ])
+        assert result.exit_code == 0, result.output
+
+        prov = _record(tmp_path)["provenance"]
+        assert prov[head] == value
+        assert prov[other] is None  # gated off: wrong model family
+
+    @pytest.mark.parametrize("mlip,head,value,other", _HEAD_CASES)
+    def test_batch_forwards_the_head_to_every_record(self, tmp_path, emt_patched,
+                                                      mlip, head, value, other):
+        """Same forwarding, separate call site in `optimize batch`."""
+        for name in ("a", "b"):
+            d = tmp_path / name
+            d.mkdir()
+            write(str(d / "init.vasp"), bulk("Cu", "fcc", a=3.7), format="vasp")
+
+        result = runner.invoke(optimize_app, [
+            "batch", "--parent", str(tmp_path), "--mlip", mlip,
+            _flag(head), value, "--fmax", "0.5", "--max-steps", "5",
+        ])
+        assert result.exit_code == 0, result.output
+
+        for name in ("a", "b"):
+            prov = _record(tmp_path / name)["provenance"]
+            assert prov[head] == value, name
+            assert prov[other] is None, name
 
     def test_txt_file_still_written(self, tmp_path, emt_patched):
         """The .txt files are retained; the JSON supplements, not replaces."""
@@ -317,9 +380,13 @@ class TestNebRunWiring:
         from mliprun.core.neb import CustomNEB
 
         initial, final = _neb_pair()
+        # `mlip` is a default rather than fixed, so the head/task tests can
+        # ask for a real model family -- collect_provenance gates uma_task /
+        # mace_head on the tag prefix and would drop them under "test".
+        kwargs.setdefault("mlip", "test")
         neb = CustomNEB(
             initial=initial, final=final, num_images=3,
-            mlip="test", output_dir=tmp_path, **kwargs,
+            output_dir=tmp_path, **kwargs,
         )
         # run_neb builds a calculator per image via self.setup_calculator();
         # swap in EMT so the run works without a real MLIP installed.
@@ -391,6 +458,40 @@ class TestNebRunWiring:
         assert stage_params["fmax"]["value"] == pytest.approx(neb.fmax)
         assert stage_params["fmax"]["source"] == "user"
 
+    @pytest.mark.parametrize("mlip,head,value,other", _HEAD_CASES)
+    def test_neb_stage_records_the_head_the_images_ran_with(
+            self, tmp_path, monkeypatch, mlip, head, value, other):
+        """The record must name the head that produced the barrier.
+
+        A NEB barrier is exactly the kind of number CANON C3 governs, and
+        `run_neb` reads the head off `self` -- so a kwarg dropped from the
+        `collect_provenance` call is silent. Non-default values are used
+        deliberately: with the default, a forwarded value and a defaulted
+        one are indistinguishable and the assertion proves nothing.
+        """
+        neb = self._emt_neb(tmp_path, monkeypatch, mlip=mlip, **{head: value})
+        neb.run_neb(max_steps=2)
+
+        prov = _record(tmp_path)["provenance"]
+        assert prov[head] == value
+        assert prov["mlip_model"] == mlip
+        assert prov[other] is None  # gated off: wrong model family
+
+    def test_neb_restart_stage_records_a_switched_task(self, tmp_path, monkeypatch):
+        """Restarting under a different head is the C3 hazard the record
+        exists to expose; the append path must carry the new value too."""
+        neb = self._emt_neb(tmp_path, monkeypatch, mlip="uma-s-1p2",
+                            uma_task="oc25")
+        neb.run_neb(max_steps=2)
+
+        neb2 = self._emt_neb(tmp_path, monkeypatch, mlip="uma-s-1p2",
+                             uma_task="odac")
+        neb2.run_neb(max_steps=2, climb=True, append=True)
+
+        data = _record(tmp_path)
+        assert data["provenance"]["uma_task"] == "oc25"
+        assert data["stages"][1]["stage_provenance"] == {"uma_task": "odac"}
+
     def test_failed_neb_run_still_leaves_a_record(self, tmp_path, monkeypatch):
         """An exception mid-optimization must not swallow the evidence."""
         from mliprun.core.neb import CustomNEB
@@ -455,9 +556,13 @@ class TestAutonebRunWiring:
         from mliprun.core.neb import CustomNEB
 
         initial, final = _neb_pair()
+        # `mlip` is a default rather than fixed, so the head/task tests can
+        # ask for a real model family -- collect_provenance gates uma_task /
+        # mace_head on the tag prefix and would drop them under "test".
+        kwargs.setdefault("mlip", "test")
         neb = CustomNEB(
             initial=initial, final=final, num_images=3,
-            mlip="test", output_dir=tmp_path, **kwargs,
+            output_dir=tmp_path, **kwargs,
         )
         monkeypatch.setattr(neb, "setup_calculator", lambda: EMT())
         return neb
@@ -487,6 +592,20 @@ class TestAutonebRunWiring:
         params = _record(tmp_path)["parameters"]
         assert params["n_max"]["value"] == 3
         assert params["n_max"]["source"] == "user"
+
+    @pytest.mark.parametrize("mlip,head,value,other", _HEAD_CASES)
+    def test_autoneb_stage_records_the_head_the_images_ran_with(
+            self, tmp_path, monkeypatch, mlip, head, value, other):
+        """Same C3 exposure as the NEB stage, separate call site: AutoNEB
+        opens its own record. Non-default values keep the assertion
+        load-bearing (see the NEB counterpart)."""
+        neb = self._emt_neb(tmp_path, monkeypatch, mlip=mlip, **{head: value})
+        neb.run_autoneb(n_simul=1, n_max=3, maxsteps=5, climb=False)
+
+        prov = _record(tmp_path)["provenance"]
+        assert prov[head] == value
+        assert prov["mlip_model"] == mlip
+        assert prov[other] is None  # gated off: wrong model family
 
     def test_failed_autoneb_run_still_leaves_a_record(self, tmp_path, monkeypatch):
         """An exception inside AutoNEB's own run() must not swallow the


### PR DESCRIPTION
`collect_provenance` took only the model tag, so `mliprun_run.json` named `uma-s-1p2` without the `oc25` task that actually ran — that lived only in `md_params.txt`. Same for `mace_head`, across optimize, MD and NEB.

Under CANON C1 the head is its own explicit decision, never inferred; under C3 heads must never be mixed within an energy formula, since they are independent fine-tunes with independent energy zeros. A record naming only the model cannot answer "which head produced this number", so it could not serve as provenance for any energy entering a formula.

## Changes

- `uma_task` / `mace_head` as always-present nullable `provenance` fields, **gated inside `collect_provenance`** on the model-tag prefix — CLIs pass their parsed option defaults unconditionally, so a MACE run must not inherit a UMA task it never used.
- `SCHEMA_VERSION` 1 → 2. Load-bearing, not cosmetic: without it a reader cannot tell "no `uma_task` key because the record predates the field" from "`uma_task` is null because it was MACE". The `prov` ledger uses exactly that distinction to decide whether to fall back to the text file.
- Both fields added to `_PROVENANCE_DIFF_FIELDS`, so a resume that switches head is recorded — C3 forbids mixing heads, so that is the one case that must not be silent.
- New `stage_provenance_new_fields` marker. A schema-1 record resumed with the *same* head previously claimed a head switch, because `.get()` cannot distinguish an absent key from a null one. Such fields now report as new-and-unrecorded rather than as changed. The stored `schema_version` is deliberately not rewritten on append.
- Threaded through `run_optimization`, `run_md`, both NEB stages, and the optimize/md CLI commands.

## Verification

236 tests (was 222), no golden moved, 100% diff coverage on changed source lines.

The new forwarding assertions read the head back out of the written record rather than out of a captured kwarg dict, and use non-default heads so a CLI-parsed value and an engine default stay distinguishable. Verified by mutation: deleting a single forwarding kwarg fails exactly the corresponding test.

One trap worth knowing: parametrize ids named `uma`/`mace` are silently skipped, because pytest puts a callspec id into `item.keywords` and `conftest.py` auto-skips on those. Ids are now full model tags, with an inline comment. Making `conftest.py` marker-only (`get_closest_marker`) is a known one-line follow-up.

Design: `docs/superpowers/specs/2026-07-29-run-record-head-provenance-design.md`
Driven by prov's MD capture work, which currently has to parse `md_params.txt` to recover the head.

🤖 Generated with [Claude Code](https://claude.com/claude-code)